### PR TITLE
Adjust headings

### DIFF
--- a/client/public/locales/en-GB/translation.json
+++ b/client/public/locales/en-GB/translation.json
@@ -53,7 +53,7 @@
     },
     "home": {
       "title": "Central Operations Platform",
-      "header": "Operational dashboard",
+      "heading": "Operational dashboard",
       "card": {
         "forms": {
           "footer": "Submit a form"
@@ -108,7 +108,7 @@
       "title": "Tasks",
       "list": {
         "status": "Open",
-        "caption": "Tasks",
+        "heading": "Tasks",
         "title": "Tasks to complete",
         "size": "{{count}} tasks assigned to you"
       }

--- a/client/public/locales/en-GB/translation.json
+++ b/client/public/locales/en-GB/translation.json
@@ -79,7 +79,7 @@
     },
     "forms": {
       "list": {
-        "caption": "Operational forms",
+        "heading": "Operational forms",
         "size": "{{count}} forms",
         "title": "Operational forms | Central Operations Platform",
         "load-more": "Load more",

--- a/client/public/locales/en-GB/translation.json
+++ b/client/public/locales/en-GB/translation.json
@@ -13,7 +13,8 @@
     "401/403": "Unable to complete your request due to authorization issues.",
     "400": "Unable to complete your request due to form submission issues.",
     "50x": "Internal system error",
-    "contact-support": "Please",
+    "contact-support-prefix": "Please",
+    "contact-support-link-text": "contact support",
     "error-info": "URL {{path}} - Code: {{status}}"
   },
   "render": {

--- a/client/public/locales/en-GB/translation.json
+++ b/client/public/locales/en-GB/translation.json
@@ -12,8 +12,8 @@
     "409": "The form has already been submitted",
     "401/403": "Unable to complete your request due to authorization issues.",
     "400": "Unable to complete your request due to form submission issues.",
-    "50x": "Internal system error.",
-    "contact-support": "Please contact support by clicking",
+    "50x": "Internal system error",
+    "contact-support": "Please",
     "error-info": "URL {{path}} - Code: {{status}}"
   },
   "render": {

--- a/client/src/components/AccessibilityStatement.jsx
+++ b/client/src/components/AccessibilityStatement.jsx
@@ -5,7 +5,7 @@ const AccessibilityStatement = () => (
     <main className="govuk-main-wrapper">
       <div className="govuk-grid-row">
         <div className="govuk-grid-column-two-thirds">
-          <h1 className="govuk-heading-xl">
+          <h1 className="govuk-heading-l">
             Accessibility statement for Central Operations Platform (COP)
           </h1>
           <p className="govuk-body">
@@ -41,7 +41,7 @@ const AccessibilityStatement = () => (
             has advice on making your device easier to use if you have a disability.
           </p>
 
-          <h2 className="govuk-heading-l">How accessible this website is</h2>
+          <h2 className="govuk-heading-m">How accessible this website is</h2>
           <p className="govuk-body">
             We aim to meet international accessibility guidelines. However, this may not always be
             possible, or we may have missed a problem.
@@ -92,7 +92,7 @@ const AccessibilityStatement = () => (
             statement.
           </p>
 
-          <h2 className="govuk-heading-l">Feedback and contact information</h2>
+          <h2 className="govuk-heading-m">Feedback and contact information</h2>
           <p className="govuk-body">If you have difficulty using this service, contact us by:</p>
           <ul className="govuk-list govuk-list--bullet">
             <li>
@@ -111,7 +111,7 @@ const AccessibilityStatement = () => (
             <li>Calling the service desk on 0845 000 0050.</li>
           </ul>
 
-          <h2 className="govuk-heading-l">Reporting accessibility problems with this website</h2>
+          <h2 className="govuk-heading-m">Reporting accessibility problems with this website</h2>
           <p className="govuk-body">
             As part of providing this service, we may need to send you messages or documents. Tell
             us how you want us to send messages or documents to you. Tell us if you need them in a
@@ -123,7 +123,7 @@ const AccessibilityStatement = () => (
             details above (in feedback and contact information section) to tell us.
           </p>
 
-          <h2 className="govuk-heading-l">Enforcement procedure</h2>
+          <h2 className="govuk-heading-m">Enforcement procedure</h2>
           <p className="govuk-body">
             The Equality and Human Rights Commission (EHRC) is responsible for enforcing the Public
             Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018
@@ -149,7 +149,7 @@ const AccessibilityStatement = () => (
             in Northern Ireland.
           </p>
 
-          <h2 className="govuk-heading-l">
+          <h2 className="govuk-heading-m">
             Technical information about this website’s accessibility
           </h2>
           <p className="govuk-body">
@@ -158,7 +158,7 @@ const AccessibilityStatement = () => (
             Regulations 2018.
           </p>
 
-          <h2 className="govuk-heading-l">Compliance status</h2>
+          <h2 className="govuk-heading-m">Compliance status</h2>
           <p className="govuk-body">
             This website is not compliant with the{' '}
             <a href="https://www.w3.org/TR/WCAG21/" target="_blank" rel="noopener noreferrer">
@@ -167,12 +167,12 @@ const AccessibilityStatement = () => (
             AA standard. The non-compliances are listed below.
           </p>
 
-          <h2 className="govuk-heading-l">Non-accessible content</h2>
+          <h2 className="govuk-heading-m">Non-accessible content</h2>
           <p className="govuk-body">
             The content listed below is non-accessible for the following reasons.
           </p>
 
-          <h3 className="govuk-heading-m">Non-compliance with the accessibility regulations</h3>
+          <h3 className="govuk-heading-s">Non-compliance with the accessibility regulations</h3>
           <ul className="govuk-list govuk-list--bullet">
             <li>
               Pre-recorded Audio-only and Video-only (1.2.1) – there is no transcript or audio
@@ -261,7 +261,7 @@ const AccessibilityStatement = () => (
             </li>
           </ul>
 
-          <h3 className="govuk-heading-m">What we’re doing to improve accessibility</h3>
+          <h3 className="govuk-heading-s">What we’re doing to improve accessibility</h3>
           <p className="govuk-body">
             Our plan below describes how and when we plan to improve the accessibility of this
             service:
@@ -338,7 +338,7 @@ const AccessibilityStatement = () => (
             <li>(2.4.7) Ensure that scrollable region has keyboard access.</li>
           </ul>
 
-          <h3 className="govuk-heading-m">Disproportionate burden</h3>
+          <h3 className="govuk-heading-s">Disproportionate burden</h3>
           <p className="govuk-body">
             The National Security (CT) referral form on COP currently has a list of accessibility
             issues. The COP team are aware of this and will not be making changes due to descoping
@@ -346,7 +346,7 @@ const AccessibilityStatement = () => (
             feedback and contact information section).
           </p>
 
-          <h3 className="govuk-heading-m">
+          <h3 className="govuk-heading-s">
             Content that’s not within the scope of the accessibility regulations
           </h3>
           <h4 className="govuk-heading-s">PDFs</h4>
@@ -358,7 +358,7 @@ const AccessibilityStatement = () => (
             At this time, we have not identified any content that is not within scope of the
             accessibility regulations.
           </p>
-          <h2 className="govuk-heading-l">Preparation of this accessibility statement</h2>
+          <h2 className="govuk-heading-m">Preparation of this accessibility statement</h2>
           <p className="govuk-body">
             This statement was prepared on 17th September 2020. It was last reviewed on 17th
             September 2020.

--- a/client/src/components/PrivacyAndCookiePolicy.jsx
+++ b/client/src/components/PrivacyAndCookiePolicy.jsx
@@ -6,7 +6,7 @@ const PrivacyAndCookiePolicy = () => {
       <main className="govuk-main-wrapper">
         <div className="govuk-grid-row">
           <div className="govuk-grid-column-two-thirds">
-            <h1 className="govuk-heading-xl">Privacy notice for Home Office Workforce</h1>
+            <h1 className="govuk-heading-l">Privacy notice for Home Office Workforce</h1>
             <p className="govuk-body">
               Provision of the Central Operations Platform (COP) is from Borders Systems and the
               Digital, Data and Technology directorate, both of which are part of the Home Office.
@@ -20,7 +20,7 @@ const PrivacyAndCookiePolicy = () => {
               This privacy policy applies only to the actions of COP and users of COP. It does not
               extend to any websites that can be accessed from COP.
             </p>
-            <h2 className="govuk-heading-l">What data we need</h2>
+            <h2 className="govuk-heading-m">What data we need</h2>
             <p className="govuk-body">The personal data we collect from you on COP may include:</p>
             <ul className="govuk-list govuk-list--bullet">
               <li>your full name</li>
@@ -54,7 +54,7 @@ const PrivacyAndCookiePolicy = () => {
               All information added to the platform is linked to your unique user ID for audit
               purposes.
             </p>
-            <h2 className="govuk-heading-l">Cookies</h2>
+            <h2 className="govuk-heading-m">Cookies</h2>
             <p className="govuk-body">
               COP uses cookies and you cannot access COP from a non-Home Office device.
             </p>
@@ -96,7 +96,7 @@ const PrivacyAndCookiePolicy = () => {
               clicking Ctrl+H and navigating to the option to clear history, of which cookies can
               usually be found as a subset.
             </p>
-            <h2 className="govuk-heading-l">Why we need this data</h2>
+            <h2 className="govuk-heading-m">Why we need this data</h2>
             <p className="govuk-body">
               We use cookie information to enable you to log into the service that we provide and to
               link information you add into COP to your account.
@@ -123,7 +123,7 @@ const PrivacyAndCookiePolicy = () => {
               this to help make sure that the site is meeting the needs of its users and help us to
               make improvements to the site and service that we provide.
             </p>
-            <h2 className="govuk-heading-l">What we do with your data</h2>
+            <h2 className="govuk-heading-m">What we do with your data</h2>
             <p className="govuk-body">
               The data we collect may be shared with supplier organisations, other government
               departments, agencies and public bodies, but only when there is an appropriate Border
@@ -145,7 +145,7 @@ const PrivacyAndCookiePolicy = () => {
               information to initially identify a user when a website is visited, analytical
               information and session data temporarily stored for the visit.
             </p>
-            <h2 className="govuk-heading-l">How long we keep your data</h2>
+            <h2 className="govuk-heading-m">How long we keep your data</h2>
             <p className="govuk-body">We will only retain your personal data for as long as:</p>
             <ul className="govuk-list govuk-list--bullet">
               <li>it is needed for the purposes set out in this document</li>
@@ -155,7 +155,7 @@ const PrivacyAndCookiePolicy = () => {
               In general, this means that we will only hold your personal data for the time you are
               a member of Border Force and then for a maximum of 5 years after you leave the Force.
             </p>
-            <h2 className="govuk-heading-l">Where your data is processed and stored</h2>
+            <h2 className="govuk-heading-m">Where your data is processed and stored</h2>
             <p className="govuk-body">
               We design, build and run our systems to make sure that your data is as safe as
               possible while it is being processed or stored. We store your data on an assured
@@ -167,7 +167,7 @@ const PrivacyAndCookiePolicy = () => {
               Notify for a maximum of 7 days; this is stored within the European Economic Area
               (EEA).
             </p>
-            <h2 className="govuk-heading-l">How we protect your data and keep it secure</h2>
+            <h2 className="govuk-heading-m">How we protect your data and keep it secure</h2>
             <p className="govuk-body">
               We are committed to doing all that we can to keep your data secure. We have set up
               systems and processes to prevent unauthorised access or disclosure of your data—for
@@ -177,7 +177,7 @@ const PrivacyAndCookiePolicy = () => {
               We also make sure that any third parties that we deal with keep all personal data they
               process on our behalf secure.
             </p>
-            <h2 className="govuk-heading-l">What are your rights?</h2>
+            <h2 className="govuk-heading-m">What are your rights?</h2>
             <p className="govuk-body">You have the right to request:</p>
             <ul className="govuk-list govuk-list--bullet">
               <li>information about how your personal data is processed</li>
@@ -224,7 +224,7 @@ const PrivacyAndCookiePolicy = () => {
               </a>
               .
             </p>
-            <h2 className="govuk-heading-l">Changes to this notice</h2>
+            <h2 className="govuk-heading-m">Changes to this notice</h2>
             <p className="govuk-body">
               We may modify or amend this privacy notice at our discretion at any time. When we make
               changes to this notice, we will amend the last modified date at the top of this page.

--- a/client/src/components/__snapshots__/AccessibilityStatement.test.jsx.snap
+++ b/client/src/components/__snapshots__/AccessibilityStatement.test.jsx.snap
@@ -14,7 +14,7 @@ exports[`Accessibility Statement page matches snapshot 1`] = `
         className="govuk-grid-column-two-thirds"
       >
         <h1
-          className="govuk-heading-xl"
+          className="govuk-heading-l"
         >
           Accessibility statement for Central Operations Platform (COP)
         </h1>
@@ -80,7 +80,7 @@ exports[`Accessibility Statement page matches snapshot 1`] = `
           has advice on making your device easier to use if you have a disability.
         </p>
         <h2
-          className="govuk-heading-l"
+          className="govuk-heading-m"
         >
           How accessible this website is
         </h2>
@@ -137,7 +137,7 @@ exports[`Accessibility Statement page matches snapshot 1`] = `
           We know some parts of this website are not fully accessible. You can see a full list of any issues we currently know about in the Non-accessible content section of this statement.
         </p>
         <h2
-          className="govuk-heading-l"
+          className="govuk-heading-m"
         >
           Feedback and contact information
         </h2>
@@ -172,7 +172,7 @@ exports[`Accessibility Statement page matches snapshot 1`] = `
           </li>
         </ul>
         <h2
-          className="govuk-heading-l"
+          className="govuk-heading-m"
         >
           Reporting accessibility problems with this website
         </h2>
@@ -187,7 +187,7 @@ exports[`Accessibility Statement page matches snapshot 1`] = `
           We’re always looking to improve the accessibility of our websites and services. If you find any problems or think we’re not meeting accessibility requirements, use the contact details above (in feedback and contact information section) to tell us.
         </p>
         <h2
-          className="govuk-heading-l"
+          className="govuk-heading-m"
         >
           Enforcement procedure
         </h2>
@@ -221,7 +221,7 @@ exports[`Accessibility Statement page matches snapshot 1`] = `
           who are responsible for enforcing the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018 (the ‘accessibility regulations’) in Northern Ireland.
         </p>
         <h2
-          className="govuk-heading-l"
+          className="govuk-heading-m"
         >
           Technical information about this website’s accessibility
         </h2>
@@ -231,7 +231,7 @@ exports[`Accessibility Statement page matches snapshot 1`] = `
           The Home Office is committed to making its website accessible, in accordance with the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018.
         </p>
         <h2
-          className="govuk-heading-l"
+          className="govuk-heading-m"
         >
           Compliance status
         </h2>
@@ -251,7 +251,7 @@ exports[`Accessibility Statement page matches snapshot 1`] = `
           AA standard. The non-compliances are listed below.
         </p>
         <h2
-          className="govuk-heading-l"
+          className="govuk-heading-m"
         >
           Non-accessible content
         </h2>
@@ -261,7 +261,7 @@ exports[`Accessibility Statement page matches snapshot 1`] = `
           The content listed below is non-accessible for the following reasons.
         </p>
         <h3
-          className="govuk-heading-m"
+          className="govuk-heading-s"
         >
           Non-compliance with the accessibility regulations
         </h3>
@@ -327,7 +327,7 @@ exports[`Accessibility Statement page matches snapshot 1`] = `
           </li>
         </ul>
         <h3
-          className="govuk-heading-m"
+          className="govuk-heading-s"
         >
           What we’re doing to improve accessibility
         </h3>
@@ -433,7 +433,7 @@ exports[`Accessibility Statement page matches snapshot 1`] = `
           </li>
         </ul>
         <h3
-          className="govuk-heading-m"
+          className="govuk-heading-s"
         >
           Disproportionate burden
         </h3>
@@ -443,7 +443,7 @@ exports[`Accessibility Statement page matches snapshot 1`] = `
           The National Security (CT) referral form on COP currently has a list of accessibility issues. The COP team are aware of this and will not be making changes due to descoping this form soon, if you need any help with this form please contact us (please see feedback and contact information section).
         </p>
         <h3
-          className="govuk-heading-m"
+          className="govuk-heading-s"
         >
           Content that’s not within the scope of the accessibility regulations
         </h3>
@@ -463,7 +463,7 @@ exports[`Accessibility Statement page matches snapshot 1`] = `
           At this time, we have not identified any content that is not within scope of the accessibility regulations.
         </p>
         <h2
-          className="govuk-heading-l"
+          className="govuk-heading-m"
         >
           Preparation of this accessibility statement
         </h2>

--- a/client/src/components/__snapshots__/PrivacyAndCookiePolicy.test.jsx.snap
+++ b/client/src/components/__snapshots__/PrivacyAndCookiePolicy.test.jsx.snap
@@ -14,7 +14,7 @@ exports[`Privacy Policy page matches snapshot 1`] = `
         className="govuk-grid-column-two-thirds"
       >
         <h1
-          className="govuk-heading-xl"
+          className="govuk-heading-l"
         >
           Privacy notice for Home Office Workforce
         </h1>
@@ -34,7 +34,7 @@ exports[`Privacy Policy page matches snapshot 1`] = `
           This privacy policy applies only to the actions of COP and users of COP. It does not extend to any websites that can be accessed from COP.
         </p>
         <h2
-          className="govuk-heading-l"
+          className="govuk-heading-m"
         >
           What data we need
         </h2>
@@ -104,7 +104,7 @@ exports[`Privacy Policy page matches snapshot 1`] = `
           All information added to the platform is linked to your unique user ID for audit purposes.
         </p>
         <h2
-          className="govuk-heading-l"
+          className="govuk-heading-m"
         >
           Cookies
         </h2>
@@ -159,7 +159,7 @@ exports[`Privacy Policy page matches snapshot 1`] = `
           A user can remove cookies by deleting them from the browser. This can be done by clicking Ctrl+H and navigating to the option to clear history, of which cookies can usually be found as a subset.
         </p>
         <h2
-          className="govuk-heading-l"
+          className="govuk-heading-m"
         >
           Why we need this data
         </h2>
@@ -189,7 +189,7 @@ exports[`Privacy Policy page matches snapshot 1`] = `
           We use a service called Matomo to collect information about how you use the COP. We do this to help make sure that the site is meeting the needs of its users and help us to make improvements to the site and service that we provide.
         </p>
         <h2
-          className="govuk-heading-l"
+          className="govuk-heading-m"
         >
           What we do with your data
         </h2>
@@ -224,7 +224,7 @@ exports[`Privacy Policy page matches snapshot 1`] = `
           Information captured via cookies within Matomo includes a unique visitor ID, information to initially identify a user when a website is visited, analytical information and session data temporarily stored for the visit.
         </p>
         <h2
-          className="govuk-heading-l"
+          className="govuk-heading-m"
         >
           How long we keep your data
         </h2>
@@ -249,7 +249,7 @@ exports[`Privacy Policy page matches snapshot 1`] = `
           In general, this means that we will only hold your personal data for the time you are a member of Border Force and then for a maximum of 5 years after you leave the Force.
         </p>
         <h2
-          className="govuk-heading-l"
+          className="govuk-heading-m"
         >
           Where your data is processed and stored
         </h2>
@@ -264,7 +264,7 @@ exports[`Privacy Policy page matches snapshot 1`] = `
           We use GOV.UK Notify, a service provided by Cabinet Office to send you notifications about the COP. Any information included in the notification email or SMS is stored in Notify for a maximum of 7 days; this is stored within the European Economic Area (EEA).
         </p>
         <h2
-          className="govuk-heading-l"
+          className="govuk-heading-m"
         >
           How we protect your data and keep it secure
         </h2>
@@ -279,7 +279,7 @@ exports[`Privacy Policy page matches snapshot 1`] = `
           We also make sure that any third parties that we deal with keep all personal data they process on our behalf secure.
         </p>
         <h2
-          className="govuk-heading-l"
+          className="govuk-heading-m"
         >
           What are your rights?
         </h2>
@@ -349,7 +349,7 @@ exports[`Privacy Policy page matches snapshot 1`] = `
           .
         </p>
         <h2
-          className="govuk-heading-l"
+          className="govuk-heading-m"
         >
           Changes to this notice
         </h2>

--- a/client/src/components/alert/ApiErrorAlert.jsx
+++ b/client/src/components/alert/ApiErrorAlert.jsx
@@ -55,15 +55,16 @@ const ApiErrorAlert = ({ errors }) => {
         <ul className="govuk-list govuk-error-summary__list">{errors.map(buildMessage)}</ul>
       </div>
       <p className="govuk-body">
-        {t('error.contact-support')}{' '}
+        {t('error.contact-support-prefix')}{' '}
         <a
           className="govuk-link"
           rel="noopener noreferrer"
           target="_blank"
           href={config.get('serviceDeskUrl')}
         >
-          contact support
-        </a>.
+          {t('error.contact-support-link-text')}
+        </a>
+        .
       </p>
       <details className="govuk-details">
         <summary className="govuk-details__summary">

--- a/client/src/components/alert/ApiErrorAlert.jsx
+++ b/client/src/components/alert/ApiErrorAlert.jsx
@@ -3,7 +3,6 @@ import { useTranslation } from 'react-i18next';
 import PropType from 'prop-types';
 import { v4 as uuidv4 } from 'uuid';
 import config from 'react-global-configuration';
-import { ERROR_COLOUR } from 'govuk-colours';
 
 const ApiErrorAlert = ({ errors }) => {
   const { t } = useTranslation();
@@ -34,9 +33,9 @@ const ApiErrorAlert = ({ errors }) => {
     }
     return (
       <li key={uuidv4()}>
-        <h4 style={{ color: ERROR_COLOUR }} className="govuk-heading-s">
+        <p className="govuk-error-message">
           {errorMessage}
-        </h4>
+        </p>
       </li>
     );
   };
@@ -49,13 +48,13 @@ const ApiErrorAlert = ({ errors }) => {
       tabIndex="-1"
       data-module="govuk-error-summary"
     >
-      <h2 className="govuk-error-summary__title" id="error-summary-title">
+      <h1 className="govuk-error-summary__title" id="error-summary-title">
         {t('error.title')}
-      </h2>
+      </h1>
       <div className="govuk-error-summary__body">
         <ul className="govuk-list govuk-error-summary__list">{errors.map(buildMessage)}</ul>
       </div>
-      <h4 className="govuk-heading-s">
+      <p className="govuk-body">
         {t('error.contact-support')}{' '}
         <a
           className="govuk-link"
@@ -63,9 +62,9 @@ const ApiErrorAlert = ({ errors }) => {
           target="_blank"
           href={config.get('serviceDeskUrl')}
         >
-          here
-        </a>
-      </h4>
+          contact support
+        </a>.
+      </p>
       <details className="govuk-details">
         <summary className="govuk-details__summary">
           <span className="govuk-details__summary-text">{t('error.details')}</span>

--- a/client/src/components/alert/SubmissionSuccessAlert.jsx
+++ b/client/src/components/alert/SubmissionSuccessAlert.jsx
@@ -8,7 +8,7 @@ const SubmissionSuccessAlert = ({ message, reference, handleOnClose }) => {
     <div className="govuk-grid-row">
       <div className="govuk-grid-column-full">
         <div className="govuk-panel govuk-panel--confirmation">
-          <h2 className="govuk-panel__title">{message}</h2>
+          <h1 className="govuk-panel__title">{message}</h1>
           {reference ? (
             <div className="govuk-panel__body">
               <strong>{t('pages.form.submission.your-reference', { reference })}</strong>

--- a/client/src/pages/forms/FormsListPage.jsx
+++ b/client/src/pages/forms/FormsListPage.jsx
@@ -105,8 +105,10 @@ const FormsListPage = () => {
     <>
       <div className="govuk-grid-row">
         <div className="govuk-grid-column-two-thirds">
-          <span className="govuk-caption-l">{t('pages.forms.list.caption')}</span>
-          <h2 className="govuk-heading-l">{t('pages.forms.list.size', { count: forms.total })}</h2>
+          <span className="govuk-caption-l">
+            {t('pages.forms.list.size', { count: forms.total })}
+          </span>
+          <h1 className="govuk-heading-l">{t('pages.forms.list.caption')}</h1>
         </div>
         <div className="govuk-grid-column-one-third">
           <div className="govuk-form-group">

--- a/client/src/pages/forms/FormsListPage.jsx
+++ b/client/src/pages/forms/FormsListPage.jsx
@@ -108,7 +108,7 @@ const FormsListPage = () => {
           <span className="govuk-caption-l">
             {t('pages.forms.list.size', { count: forms.total })}
           </span>
-          <h1 className="govuk-heading-l">{t('pages.forms.list.caption')}</h1>
+          <h1 className="govuk-heading-l">{t('pages.forms.list.heading')}</h1>
         </div>
         <div className="govuk-grid-column-one-third">
           <div className="govuk-form-group">

--- a/client/src/pages/forms/FormsListPage.test.jsx
+++ b/client/src/pages/forms/FormsListPage.test.jsx
@@ -47,7 +47,7 @@ describe('FormsListPage', () => {
       await new Promise((resolve) => setImmediate(resolve));
       await wrapper.update();
     });
-    expect(wrapper.find('h2').at(0).text()).not.toBe('');
+    expect(wrapper.find('h1').at(0).text()).not.toBe('');
 
     wrapper
       .find('a')
@@ -70,7 +70,7 @@ describe('FormsListPage', () => {
       await wrapper.update();
     });
 
-    expect(wrapper.find('h2').at(0).text()).not.toBe('');
+    expect(wrapper.find('h1').at(0).text()).not.toBe('');
   });
 
   it('load more does not exist if results less than 20', async () => {

--- a/client/src/pages/home/index.jsx
+++ b/client/src/pages/home/index.jsx
@@ -99,10 +99,10 @@ const Home = () => {
     <div className="govuk-!-margin-top-7">
       <div className="govuk-grid-row">
         <div className="govuk-grid-column-full">
-          <h2 className="govuk-heading-l">
-            <span className="govuk-caption-l">{t('pages.home.header')}</span>
-            {keycloak.tokenParsed.given_name} {keycloak.tokenParsed.family_name}
-          </h2>
+          <span className="govuk-caption-l">
+            {keycloak.tokenParsed.name}
+          </span>
+          <h1 className="govuk-heading-l">{t('pages.home.header')}</h1>
         </div>
       </div>
       <div className="govuk-grid-row">

--- a/client/src/pages/home/index.jsx
+++ b/client/src/pages/home/index.jsx
@@ -99,10 +99,8 @@ const Home = () => {
     <div className="govuk-!-margin-top-7">
       <div className="govuk-grid-row">
         <div className="govuk-grid-column-full">
-          <span className="govuk-caption-l">
-            {keycloak.tokenParsed.name}
-          </span>
-          <h1 className="govuk-heading-l">{t('pages.home.header')}</h1>
+          <span className="govuk-caption-l">{keycloak.tokenParsed.name}</span>
+          <h1 className="govuk-heading-l">{t('pages.home.heading')}</h1>
         </div>
       </div>
       <div className="govuk-grid-row">

--- a/client/src/pages/tasks/TasksListPage.jsx
+++ b/client/src/pages/tasks/TasksListPage.jsx
@@ -133,7 +133,7 @@ const TasksListPage = () => {
       <div className="govuk-grid-row">
         <div className="govuk-grid-column-two-thirds">
           <span className="govuk-caption-l">{t('pages.tasks.list.size', { count: data.total })}</span>
-          <h1 className="govuk-heading-l">{t('pages.tasks.list.caption')}</h1>
+          <h1 className="govuk-heading-l">{t('pages.tasks.list.heading')}</h1>
         </div>
       </div>
       <div className="govuk-grid-row">

--- a/client/src/pages/tasks/TasksListPage.jsx
+++ b/client/src/pages/tasks/TasksListPage.jsx
@@ -132,8 +132,8 @@ const TasksListPage = () => {
     <>
       <div className="govuk-grid-row">
         <div className="govuk-grid-column-two-thirds">
-          <span className="govuk-caption-l">{t('pages.tasks.list.caption')}</span>
-          <h2 className="govuk-heading-l">{t('pages.tasks.list.size', { count: data.total })}</h2>
+          <span className="govuk-caption-l">{t('pages.tasks.list.size', { count: data.total })}</span>
+          <h1 className="govuk-heading-l">{t('pages.tasks.list.caption')}</h1>
         </div>
       </div>
       <div className="govuk-grid-row">


### PR DESCRIPTION
Set headings to be from H1 large downward. Also:

• Minor tweaks to API error message formatting
• Set user's name on dashboard to Keycloak name
• Render main headings as h1, subheadings as captions