### PR TITLE
COP-2794 Add nav link to My profile

### DIFF
--- a/client/public/locales/en-GB/translation.json
+++ b/client/public/locales/en-GB/translation.json
@@ -30,6 +30,7 @@
     }
   },
   "header": {
+    "my-profile": "My profile",
     "service-name": "Central Operations Platform",
     "sign-out": "Sign out",
     "support": "Support",

--- a/client/src/components/header/index.jsx
+++ b/client/src/components/header/index.jsx
@@ -31,6 +31,16 @@ const Header = () => {
             </div>
             <StyledCol>
               <NavLink
+                id="myprofile"
+                className="govuk-header__link"
+                onClick={async (e) => {
+                  e.preventDefault();
+                  await navigation.navigate('/forms/edit-your-profile');
+                }}
+              >
+                {t('header.my-profile')}
+              </NavLink>
+              <NavLink
                 id="support"
                 className="govuk-header__link"
                 href={config.get('supportUrl')}

--- a/client/src/components/header/index.test.jsx
+++ b/client/src/components/header/index.test.jsx
@@ -8,6 +8,11 @@ describe('Header', () => {
     shallow(<Header />);
   });
 
+  it('can click my profile', () => {
+    const wrapper = mount(<Header />);
+    wrapper.find('a[id="myprofile"]').at(0).simulate('click');
+    expect(mockNavigate).toBeCalledWith('/forms/edit-your-profile');
+  });
   it('can click logout', () => {
     const wrapper = mount(<Header />);
     wrapper.find('a[id="logout"]').at(0).simulate('click');


### PR DESCRIPTION
### AC
User should be able to navigate to `forms/edit-your-profile` by clicking the My profile navigation link in the header.

### Updated
- Updated header/index.jsx to have a My profile `NavLink` 
- en-GB/translation.json has been updated to contain a `my-profile` prop inside the `header` prop
- Added assertion to header/index.test.jsx for the above AC

### Notes
- `navigation.navigate()` used for navigation instead of standard `href` in NavLink. This is done as obtaining the edit-your-profile form is asynchronous
- Currently, there is no `edit-your-profile` functionality and so this navigates to an empty page

### To test
- Pull and run cop-ui
- Login to cop-ui
- Click 'My profile' in the header
- You should be navigated to the `forms/edit-your-profile` page
- If you click on the `My profile` whilst on the `forms/edit-your-profile` page, you should stay on this page without triggering a re-render