### PR TITLE
Update ref data variable to one used by form-api

### DIFF
--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -32,7 +32,7 @@ zuul:
     refdata-service:
       path: /refdata/**
       strip-prefix: true
-      url: ${refData.url:http://localhost:9002}
+      url: ${referenceDataUrl:http://localhost:9002}
     form-service:
       path: /form/**
       strip-prefix: false


### PR DESCRIPTION
Confirmed with Anil we should use `referenceDataUrl` and he is updating the secrets as that is what the form api looks for