### PR TITLE
COP-2819 Add Cases box

### DIFF
--- a/client/public/locales/en-GB/translation.json
+++ b/client/public/locales/en-GB/translation.json
@@ -46,6 +46,11 @@
     "copyright": "© Crown copyright"
   },
   "pages": {
+    "cases": {
+      "list": {
+        "title": "Case view | Central Operations Platform"
+      }      
+    },
     "accessibility": {
       "title": "Accessibility Statement | Central Operations Platform"
     },

--- a/client/public/locales/en-GB/translation.json
+++ b/client/public/locales/en-GB/translation.json
@@ -57,11 +57,16 @@
       "heading": "Operational dashboard",
       "card": {
         "forms": {
+          "title": "Forms",
           "footer": "Submit a form"
         },
         "tasks": {
-          "title": "Tasks",
+          "title": "tasks assigned to you",
           "footer": "Tasks assigned to you"
+        },
+        "cases": {
+          "title": "Cases",
+          "footer": "View active or closed cases"
         }
       }
     },

--- a/client/src/pages/cases/routes.js
+++ b/client/src/pages/cases/routes.js
@@ -15,7 +15,7 @@ const routes = mount({
   '/:caseId': map((request, context) =>
     withAuthentication(
       route({
-        title: context.t('pages.cases.title'),
+        title: context.t('pages.cases.list.title'),
         view: <CasePage caseId={request.params.caseId} />,
       })
     )

--- a/client/src/pages/home/components/Card.jsx
+++ b/client/src/pages/home/components/Card.jsx
@@ -18,7 +18,7 @@ const Card = ({ href, handleClick, footer, count, isLoading, title }) => {
       );
     }
     return (
-      <span id="count" className="govuk-!-font-size-36 govuk-!-font-weight-bold">
+      <span id="title" className="govuk-!-font-size-36 govuk-!-font-weight-bold">
         {title}
       </span>
     );

--- a/client/src/pages/home/components/Card.jsx
+++ b/client/src/pages/home/components/Card.jsx
@@ -3,41 +3,62 @@ import PropTypes from 'prop-types';
 import './_card.scss';
 import { useTranslation } from 'react-i18next';
 
-const Card = ({ href, handleClick, footer, count, isLoading }) => {
+const Card = ({ href, handleClick, footer, count, isLoading, title }) => {
   const { t } = useTranslation();
+
+  const renderTitle = () => {
+    if ((count === 0 || count) && title) {
+      return (
+        <>
+          <span id="count" className="govuk-!-font-size-48 govuk-!-font-weight-bold">
+            {count}
+          </span>
+          <span className="govuk-!-font-size-19 govuk-!-font-weight-bold">{title}</span>
+        </>
+      );
+    }
+    return (
+      <span id="count" className="govuk-!-font-size-36 govuk-!-font-weight-bold">
+        {title}
+      </span>
+    );
+  };
+
   return (
-    <div className="govuk-grid-row">
-      <div className="govuk-grid-column-full __card">
-        <a
-          href={href}
-          onClick={(e) => {
-            e.preventDefault();
-            handleClick();
-          }}
-          className="card__body"
-        >
-          {isLoading ? (
-            <span className="govuk-!-font-size-19 govuk-!-font-weight-bold">{t('loading')}</span>
-          ) : (
-            <span id="count" className="govuk-!-font-size-48 govuk-!-font-weight-bold">
-              {count}
-            </span>
-          )}
-        </a>
-        <div className="card__footer">
-          <span className="govuk-!-font-size-19">{footer}</span>
-        </div>
+    <div className="__card govuk-grid-column-one-third">
+      <a
+        href={href}
+        onClick={(e) => {
+          e.preventDefault();
+          handleClick();
+        }}
+        className="card__body"
+      >
+        {isLoading ? (
+          <span className="govuk-!-font-size-19 govuk-!-font-weight-bold">{t('loading')}</span>
+        ) : (
+          renderTitle()
+        )}
+      </a>
+      <div className="card__footer">
+        <span className="govuk-!-font-size-19">{footer}</span>
       </div>
     </div>
   );
 };
 
+Card.defaultProps = {
+  count: null,
+  title: '',
+};
+
 Card.propTypes = {
   isLoading: PropTypes.bool.isRequired,
-  count: PropTypes.number.isRequired,
+  count: PropTypes.number,
   href: PropTypes.string.isRequired,
   handleClick: PropTypes.func.isRequired,
   footer: PropTypes.string.isRequired,
+  title: PropTypes.string,
 };
 
 export default Card;

--- a/client/src/pages/home/components/Card.jsx
+++ b/client/src/pages/home/components/Card.jsx
@@ -50,10 +50,11 @@ const Card = ({ href, handleClick, footer, count, isLoading, title }) => {
 Card.defaultProps = {
   count: null,
   title: '',
+  isLoading: false,
 };
 
 Card.propTypes = {
-  isLoading: PropTypes.bool.isRequired,
+  isLoading: PropTypes.bool,
   count: PropTypes.number,
   href: PropTypes.string.isRequired,
   handleClick: PropTypes.func.isRequired,

--- a/client/src/pages/home/index.jsx
+++ b/client/src/pages/home/index.jsx
@@ -82,7 +82,7 @@ const Home = () => {
                 await navigation.navigate('/tasks');
               }}
               footer={t('pages.home.card.tasks.footer')}
-              title="tasks assigned to you"
+              title={t('pages.home.card.tasks.title')}
             />
           </li>
         </ul>
@@ -96,7 +96,17 @@ const Home = () => {
                 await navigation.navigate('/forms');
               }}
               footer={t('pages.home.card.forms.footer')}
-              title="Forms"
+              title={t('pages.home.card.forms.title')}
+            />
+          </li>
+          <li>
+            <Card
+              href="/cases"
+              handleClick={async () => {
+                await navigation.navigate('/cases');
+              }}
+              footer={t('pages.home.card.cases.footer')}
+              title={t('pages.home.card.cases.title')}
             />
           </li>
         </ul>

--- a/client/src/pages/home/index.jsx
+++ b/client/src/pages/home/index.jsx
@@ -13,11 +13,6 @@ const Home = () => {
 
   const axiosInstance = useAxios();
 
-  const [formsCount, setFormsCount] = useState({
-    isLoading: true,
-    count: 0,
-  });
-
   const [tasksCount, setTasksCount] = useState({
     isLoading: true,
     count: 0,
@@ -26,32 +21,6 @@ const Home = () => {
   useEffect(() => {
     const source = axios.CancelToken.source();
     if (axiosInstance) {
-      axiosInstance
-        .get('/camunda/engine-rest/process-definition/count', {
-          cancelToken: source.token,
-          params: {
-            startableInTasklist: true,
-            latestVersion: true,
-            active: true,
-          },
-        })
-        .then((response) => {
-          if (isMounted.current) {
-            setFormsCount({
-              isLoading: false,
-              count: response.data.count,
-            });
-          }
-        })
-        .catch(() => {
-          if (isMounted.current) {
-            setFormsCount({
-              isLoading: false,
-              count: 0,
-            });
-          }
-        });
-
       axiosInstance({
         method: 'POST',
         url: '/camunda/engine-rest/task/count',
@@ -88,7 +57,6 @@ const Home = () => {
     };
   }, [
     axiosInstance,
-    setFormsCount,
     setTasksCount,
     isMounted,
     keycloak.tokenParsed.groups,
@@ -124,7 +92,6 @@ const Home = () => {
           <li>
             <Card
               href="/forms"
-              isLoading={formsCount.isLoading}
               handleClick={async () => {
                 await navigation.navigate('/forms');
               }}

--- a/client/src/pages/home/index.jsx
+++ b/client/src/pages/home/index.jsx
@@ -104,28 +104,35 @@ const Home = () => {
         </div>
       </div>
       <div className="govuk-grid-row">
-        <div className="govuk-grid-column-one-half">
-          <Card
-            href="/forms"
-            isLoading={formsCount.isLoading}
-            count={formsCount.count}
-            handleClick={async () => {
-              await navigation.navigate('/forms');
-            }}
-            footer={t('pages.home.card.forms.footer')}
-          />
-        </div>
-        <div className="govuk-grid-column-one-half">
-          <Card
-            href="/tasks"
-            count={tasksCount.count}
-            isLoading={tasksCount.isLoading}
-            handleClick={async () => {
-              await navigation.navigate('/tasks');
-            }}
-            footer={t('pages.home.card.tasks.footer')}
-          />
-        </div>
+        <ul className="govuk-list">
+          <li>
+            <Card
+              href="/tasks"
+              count={tasksCount.count}
+              isLoading={tasksCount.isLoading}
+              handleClick={async () => {
+                await navigation.navigate('/tasks');
+              }}
+              footer={t('pages.home.card.tasks.footer')}
+              title="tasks assigned to you"
+            />
+          </li>
+        </ul>
+      </div>
+      <div className="govuk-grid-row">
+        <ul className="govuk-list">
+          <li>
+            <Card
+              href="/forms"
+              isLoading={formsCount.isLoading}
+              handleClick={async () => {
+                await navigation.navigate('/forms');
+              }}
+              footer={t('pages.home.card.forms.footer')}
+              title="Forms"
+            />
+          </li>
+        </ul>
       </div>
     </div>
   );

--- a/client/src/pages/home/index.test.jsx
+++ b/client/src/pages/home/index.test.jsx
@@ -30,7 +30,7 @@ describe('Home', () => {
       await wrapper.update();
     });
 
-    expect(wrapper.find(Card).length).toBe(2);
+    expect(wrapper.find(Card).length).toBe(3);
     const tasksCard = wrapper.find(Card).at(0);
 
     expect(tasksCard.find('span[id="count"]').text()).toBe('10');
@@ -42,13 +42,14 @@ describe('Home', () => {
     await act(async () => {
       await Promise.resolve(wrapper);
       await new Promise((resolve) => setImmediate(resolve));
-      await wrapper.update();
+      wrapper.update();
     });
 
-    expect(wrapper.find(Card).length).toBe(2);
     const formsCard = wrapper.find(Card).at(1);
+    const casesCard = wrapper.find(Card).at(2);
 
-    expect(formsCard.find('span[id="count"]').text()).toBe('Forms');
+    expect(formsCard.find('span[id="title"]').text()).toBe('pages.home.card.forms.title');
+    expect(casesCard.find('span[id="title"]').text()).toBe('pages.home.card.cases.title');
   });
 
   it('handles errors and sets it to zero', async () => {
@@ -62,7 +63,7 @@ describe('Home', () => {
       await wrapper.update();
     });
 
-    expect(wrapper.find(Card).length).toBe(2);
+    expect(wrapper.find(Card).length).toBe(3);
     const tasksCard = wrapper.find(Card).at(0);
 
     expect(tasksCard.find('span[id="count"]').text()).toBe('0');
@@ -80,8 +81,12 @@ describe('Home', () => {
       await wrapper.update();
     });
 
+    const casesCard = wrapper.find(Card).at(2);
     const formsCard = wrapper.find(Card).at(1);
     const tasksCard = wrapper.find(Card).at(0);
+
+    casesCard.props().handleClick();
+    expect(mockNavigate).toBeCalledWith('/cases');
 
     formsCard.props().handleClick();
     expect(mockNavigate).toBeCalledWith('/forms');

--- a/client/src/pages/home/index.test.jsx
+++ b/client/src/pages/home/index.test.jsx
@@ -17,11 +17,7 @@ describe('Home', () => {
     shallow(<Home />);
   });
 
-  it('renders forms and tasks panels', async () => {
-    mockAxios.onGet('/camunda/engine-rest/process-definition/count').reply(200, {
-      count: 10,
-    });
-
+  it('renders panels that have a count', async () => {
     mockAxios.onPost('/camunda/engine-rest/task/count').reply(200, {
       count: 10,
     });
@@ -35,16 +31,27 @@ describe('Home', () => {
     });
 
     expect(wrapper.find(Card).length).toBe(2);
-    const formsCard = wrapper.find(Card).at(0);
-    const tasksCard = wrapper.find(Card).at(1);
+    const tasksCard = wrapper.find(Card).at(0);
 
-    expect(formsCard.find('span[id="count"]').text()).toBe('10');
     expect(tasksCard.find('span[id="count"]').text()).toBe('10');
   });
 
-  it('handles errors and sets it to zero', async () => {
-    mockAxios.onGet('/camunda/engine-rest/process-definition/count').reply(500, {});
+  it('renders panels that do not have a count', async () => {
+    const wrapper = mount(<Home />);
 
+    await act(async () => {
+      await Promise.resolve(wrapper);
+      await new Promise((resolve) => setImmediate(resolve));
+      await wrapper.update();
+    });
+
+    expect(wrapper.find(Card).length).toBe(2);
+    const formsCard = wrapper.find(Card).at(1);
+
+    expect(formsCard.find('span[id="count"]').text()).toBe('Forms');
+  });
+
+  it('handles errors and sets it to zero', async () => {
     mockAxios.onPost('/camunda/engine-rest/task/count').reply(500, {});
 
     const wrapper = mount(<Home />);
@@ -56,18 +63,12 @@ describe('Home', () => {
     });
 
     expect(wrapper.find(Card).length).toBe(2);
-    const formsCard = wrapper.find(Card).at(0);
-    const tasksCard = wrapper.find(Card).at(1);
+    const tasksCard = wrapper.find(Card).at(0);
 
-    expect(formsCard.find('span[id="count"]').text()).toBe('0');
     expect(tasksCard.find('span[id="count"]').text()).toBe('0');
   });
 
   it('can handle onlick', async () => {
-    mockAxios.onGet('/camunda/engine-rest/process-definition/count').reply(200, {
-      count: 10,
-    });
-
     mockAxios.onPost('/camunda/engine-rest/task/count').reply(200, {
       count: 10,
     });
@@ -79,8 +80,8 @@ describe('Home', () => {
       await wrapper.update();
     });
 
-    const formsCard = wrapper.find(Card).at(0);
-    const tasksCard = wrapper.find(Card).at(1);
+    const formsCard = wrapper.find(Card).at(1);
+    const tasksCard = wrapper.find(Card).at(0);
 
     formsCard.props().handleClick();
     expect(mockNavigate).toBeCalledWith('/forms');


### PR DESCRIPTION
### AC
User should be able to click on a cases panel on the dashboard that takes them to the /cases url

### Updated
- Updated `translation.json` to contain content for cases, tasks and form on the dashboard
- `cases/routes.js` has been changed to use the same head title for both single and list views
- Card title rendering now includes a condition to check if there is both a count and title to display, if so then render both items accordingly. If this this combination is not present then only render the title provided (Forms, Cases, Reports)
- Added default values for Card props that are now not required to be passed down, this is done to allow for the conditional check mentioned above.
- Removed axios call in `home/index.jsx` that returns the number of forms available to  the user, this is does not appear on COP on the dashboard and so has been removed.
- Changed jsx in `home/index.jsx` to be in accordance with the existing cop's ui, specifically, making the panels be 1/3 of their container and placing each row of panels in an unordered list
- Added tests for the cases panel
- Removed assertions in `index.test.jsx` that check for the count of forms being rendered on the dashboard. This is not a desired feature of COP.

### Notes
- The method of testing what is rendered by useTranslation needs reviewing as currently, the test is not directly testing what is rendered - only that it is sourcing from the correct prop in `translation.json`

### To test
- Pull and run cop-ui
- Login to cop-ui
- Click the 'Cases' panel
- You should be navigated to the /cases page without error
- You should see 'Case view | Central Operations Platform' as the tab title