### PR TITLE
Update reference data variable to match form api

### DIFF
--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -32,7 +32,7 @@ zuul:
     refdata-service:
       path: /refdata/**
       strip-prefix: true
-      url: ${refData.url:http://localhost:9002}
+      url: ${referenceDataUrl:http://localhost:9002}
     form-service:
       path: /form/**
       strip-prefix: false


### PR DESCRIPTION
Confirmed with Anil, we need to use `referenceDataUrl` as the variable as this is what the form api looks for. He's updated secrets as well