### PR TITLE
COP-2826 Caseview skeleton

### DIFF
--- a/client/public/locales/en-GB/translation.json
+++ b/client/public/locales/en-GB/translation.json
@@ -129,6 +129,17 @@
         "size": "{{count}} tasks assigned to you"
       }
     },
+    "cases": {
+      "title": "Cases",
+      "caption": "Case view",
+      "heading": "Cases",
+      "heading-help": "Enter a COP number in quotes to search for cases—e.g. \"COP-20200406-24\".",
+      "heading-warning": "Please note all actions are audited.",
+      "list": {
+        "title": "Cases",
+        "search-placeholder": "Search using a COP prefixed number"
+      }
+    },
     "login": {
       "title": "Login"
     }

--- a/client/public/locales/en-GB/translation.json
+++ b/client/public/locales/en-GB/translation.json
@@ -138,6 +138,10 @@
       "list": {
         "title": "Cases",
         "search-placeholder": "Search using a COP prefixed number"
+      },
+      "results-panel": {
+        "title": "Search results",
+        "caption": "Number of cases found"
       }
     },
     "login": {

--- a/client/src/pages/cases/CasePage.jsx
+++ b/client/src/pages/cases/CasePage.jsx
@@ -1,7 +1,41 @@
 import React from 'react';
+import { useTranslation } from 'react-i18next';
+import './CasesPage.scss';
 
 const CasePage = () => {
-  return <></>;
+  const { t } = useTranslation();
+
+  return (
+    <>
+      <div className="govuk-grid-row">
+        <div className="govuk-grid-column-two-thirds">
+          <span className="govuk-caption-l">{t('pages.cases.caption')}</span>
+          <h1 className="govuk-heading-l">{t('pages.cases.heading')}</h1>
+          <div className="govuk-inset-text">
+            <p>{t('pages.cases.heading-help')}</p>
+            <p>
+              <strong>{t('pages.cases.heading-warning')}</strong>
+            </p>
+          </div>
+        </div>
+        <div className="govuk-grid-column-one-third">
+          <div className="govuk-form-group">
+            <input
+              // onChange={(e) => {
+              //   search(e.target.value);
+              // }}
+              spellCheck="false"
+              className="govuk-input search__input"
+              placeholder={t('pages.cases.list.search-placeholder')}
+              id="bfNumber"
+              name="search"
+              type="text"
+            />
+          </div>
+        </div>
+      </div>
+    </>
+  );
 };
 
 export default CasePage;

--- a/client/src/pages/cases/CasePage.jsx
+++ b/client/src/pages/cases/CasePage.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
+import CasesResultsPanel from './CasesResultsPanel';
 import './CasesPage.scss';
 
 const CasePage = () => {
@@ -13,9 +14,7 @@ const CasePage = () => {
           <h1 className="govuk-heading-l">{t('pages.cases.heading')}</h1>
           <div className="govuk-inset-text">
             <p>{t('pages.cases.heading-help')}</p>
-            <p>
-              <strong>{t('pages.cases.heading-warning')}</strong>
-            </p>
+            <p className="govuk-!-font-weight-bold">{t('pages.cases.heading-warning')}</p>
           </div>
         </div>
         <div className="govuk-grid-column-one-third">
@@ -34,6 +33,7 @@ const CasePage = () => {
           </div>
         </div>
       </div>
+      <CasesResultsPanel />
     </>
   );
 };

--- a/client/src/pages/cases/CasePage.jsx
+++ b/client/src/pages/cases/CasePage.jsx
@@ -20,9 +20,6 @@ const CasePage = () => {
         <div className="govuk-grid-column-one-third">
           <div className="govuk-form-group">
             <input
-              // onChange={(e) => {
-              //   search(e.target.value);
-              // }}
               spellCheck="false"
               className="govuk-input search__input"
               placeholder={t('pages.cases.list.search-placeholder')}

--- a/client/src/pages/cases/CasesPage.scss
+++ b/client/src/pages/cases/CasesPage.scss
@@ -1,0 +1,11 @@
+@import '~govuk-frontend/govuk/settings/_colours-applied.scss';
+
+.search__input {
+  position: relative;
+  background-repeat: no-repeat;
+  background-position: center left -2px;
+  background-size: 40px 40px;
+  padding-left: 35px;
+  /* svg is the same used on the GDS site */
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 36 36' width='40' height='40'%3E%3Cpath d='M25.7 24.8L21.9 21c.7-1 1.1-2.2 1.1-3.5 0-3.6-2.9-6.5-6.5-6.5S10 13.9 10 17.5s2.9 6.5 6.5 6.5c1.6 0 3-.6 4.1-1.5l3.7 3.7 1.4-1.4zM12 17.5c0-2.5 2-4.5 4.5-4.5s4.5 2 4.5 4.5-2 4.5-4.5 4.5-4.5-2-4.5-4.5z' fill='%23505a5f'%3E%3C/path%3E%3C/svg%3E");
+}

--- a/client/src/pages/cases/CasesResultsPanel.jsx
+++ b/client/src/pages/cases/CasesResultsPanel.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+
+const CaseResultsPanel = () => {
+  const { t } = useTranslation();
+
+  return (
+    <div className="govuk-grid-row">
+      <div className="govuk-grid-column-one-quarter">
+        <h2 className="govuk-heading-m">{t('pages.cases.results-panel.title')}</h2>
+        <p className="govuk-body govuk-!-margin-bottom-1">
+          {t('pages.cases.results-panel.caption')}
+        </p>
+        <p className="govuk-body govuk-!-font-weight-bold">0</p>
+      </div>
+    </div>
+  );
+};
+
+export default CaseResultsPanel;


### PR DESCRIPTION
### AC
Cases page should show the default page styling, without functionality

### Updated
- Removed `<strong>` in favour of GDS class for bold text
- Added the search panels
- Updated titles

### Notes
- The search box and number of cases are not functional, once the styling is signed off they will be commented out until the functionality is added

### To test
- Pull and run cop-ui
- Login to cop-ui
- Go to /cases
- You should see the titles, search box, and search results panels