### PR TITLE
COP-2796 Update Phase Banner

### DIFF
--- a/client/src/components/header/index.jsx
+++ b/client/src/components/header/index.jsx
@@ -77,7 +77,7 @@ const Header = () => {
             {t('header.new-service-1')}{' '}
             <a
               className="govuk-link"
-              href={config.get('serviceDeskUrl')}
+              href={`${config.get('serviceDeskUrl')}/create/54`}
               target="_blank"
               rel="noopener noreferrer"
             >

--- a/client/src/index.scss
+++ b/client/src/index.scss
@@ -10,6 +10,7 @@ a {
 body {
   overscroll-behavior-y: none;
   font-family: 'nta', Arial, sans-serif;
+  margin: 0px;
 }
 
 .app-container {


### PR DESCRIPTION
### AC
The phase banner should stretch the full width of the page and there should be no space between the top of the page and the top of the phase banner

### Updated
- Added margin of 0px to the body
-  Changed the feedback url in header/index.jsx to point towards the correct feedback url

### To test
- Pull and run cop-ui
- Login
- Click on the feedback link in the header, this should take you to https://support.cop.homeoffice.gov.uk/servicedesk/customer/portal/3/create/54
- You should not see any margin on top of and to the side of the phase banner