### PR TITLE
COP-2826 Add details panel frame

### DIFF
--- a/client/src/pages/cases/CaseDetailsPanel.jsx
+++ b/client/src/pages/cases/CaseDetailsPanel.jsx
@@ -28,11 +28,26 @@ const CaseDetailsPanel = () => {
           <div className="govuk-form-group">
             <label className="govuk-label" htmlFor="sort">
               Order by
-              <select className="govuk-select" id="sort" name="sort">
+              <select
+                className="govuk-select govuk-!-display-block govuk-!-margin-top-1"
+                id="sort"
+                name="sort"
+              >
                 <option value="desc">Latest process start date</option>
                 <option value="acs">Earliest process start date</option>
               </select>
             </label>
+          </div>
+          <div id="businessKey" className="govuk-accordion" data-module="govuk-accordion">
+            <div className="govuk-accordion__section">
+              <div className="govuk-accordion__section-header">
+                <h4 className="govuk-accordion__section-heading">
+                  <span className="govuk-accordion__section-button" id="id">
+                    example title
+                  </span>
+                </h4>
+              </div>
+            </div>
           </div>
         </div>
       </div>

--- a/client/src/pages/cases/CaseDetailsPanel.jsx
+++ b/client/src/pages/cases/CaseDetailsPanel.jsx
@@ -1,0 +1,24 @@
+import React from 'react';
+
+const CaseDetailsPanel = () => {
+  return (
+    <>
+      <div className="govuk-grid-row govuk-card">
+        <div className="govuk-grid-column-one-half">
+          <h2 className="govuk-heading-m">BusinessKeyHere</h2>
+        </div>
+        <div className="govuk-grid-column-one-half">
+          <button
+            type="button"
+            style={{ float: 'right' }}
+            className="govuk-button govuk-button--secondary"
+          >
+            Copy case link
+          </button>
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default CaseDetailsPanel;

--- a/client/src/pages/cases/CaseDetailsPanel.jsx
+++ b/client/src/pages/cases/CaseDetailsPanel.jsx
@@ -17,6 +17,35 @@ const CaseDetailsPanel = () => {
           </button>
         </div>
       </div>
+      <div className="govuk-grid-row govuk-card govuk-!-margin-top-4">
+        <div className="govuk-grid-column-full">
+          <h3 className="govuk-heading-m">Case actions</h3>
+        </div>
+      </div>
+      <div className="govuk-grid-row govuk-card govuk-!-margin-top-4">
+        <div className="govuk-grid-column-full">
+          <h3 className="govuk-heading-m">Case history</h3>
+          <div className="govuk-form-group">
+            <label className="govuk-label" htmlFor="sort">
+              Order by
+              <select className="govuk-select" id="sort" name="sort">
+                <option value="desc">Latest process start date</option>
+                <option value="acs">Earliest process start date</option>
+              </select>
+            </label>
+          </div>
+        </div>
+      </div>
+      <div className="govuk-grid-row govuk-card govuk-!-margin-top-4">
+        <div className="govuk-grid-column-full">
+          <h3 className="govuk-heading-m">Case attachments</h3>
+        </div>
+      </div>
+      <div className="govuk-grid-row govuk-card govuk-!-margin-top-4">
+        <div className="govuk-grid-column-full">
+          <h3 className="govuk-heading-m">Case metrics</h3>
+        </div>
+      </div>
     </>
   );
 };

--- a/client/src/pages/cases/CasePage.jsx
+++ b/client/src/pages/cases/CasePage.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import CasesResultsPanel from './CasesResultsPanel';
+import CaseDetailsPanel from './CaseDetailsPanel';
 import './CasesPage.scss';
 
 const CasePage = () => {
@@ -30,7 +31,14 @@ const CasePage = () => {
           </div>
         </div>
       </div>
-      <CasesResultsPanel />
+      <div className="govuk-grid-row">
+        <div className="govuk-grid-column-one-quarter">
+          <CasesResultsPanel />
+        </div>
+        <div className="govuk-grid-column-three-quarters">
+          <CaseDetailsPanel />
+        </div>
+      </div>
     </>
   );
 };

--- a/client/src/pages/cases/CasesPage.scss
+++ b/client/src/pages/cases/CasesPage.scss
@@ -1,4 +1,6 @@
+@import "node_modules/govuk-frontend/govuk/base";
 @import '~govuk-frontend/govuk/settings/_colours-applied.scss';
+$govuk-card-border : govuk-colour('blue');
 
 .search__input {
   position: relative;
@@ -8,4 +10,11 @@
   padding-left: 35px;
   /* svg is the same used on the GDS site */
   background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 36 36' width='40' height='40'%3E%3Cpath d='M25.7 24.8L21.9 21c.7-1 1.1-2.2 1.1-3.5 0-3.6-2.9-6.5-6.5-6.5S10 13.9 10 17.5s2.9 6.5 6.5 6.5c1.6 0 3-.6 4.1-1.5l3.7 3.7 1.4-1.4zM12 17.5c0-2.5 2-4.5 4.5-4.5s4.5 2 4.5 4.5-2 4.5-4.5 4.5-4.5-2-4.5-4.5z' fill='%23505a5f'%3E%3C/path%3E%3C/svg%3E");
+}
+
+.govuk-card {
+  @include govuk-responsive-margin(6, "bottom");
+  @include govuk-responsive-padding(6, "bottom");
+  border-bottom: 3px solid $govuk-card-border;
+  box-sizing: border-box;
 }

--- a/client/src/pages/cases/CasesResultsPanel.jsx
+++ b/client/src/pages/cases/CasesResultsPanel.jsx
@@ -5,15 +5,11 @@ const CaseResultsPanel = () => {
   const { t } = useTranslation();
 
   return (
-    <div className="govuk-grid-row">
-      <div className="govuk-grid-column-one-quarter">
-        <h2 className="govuk-heading-m">{t('pages.cases.results-panel.title')}</h2>
-        <p className="govuk-body govuk-!-margin-bottom-1">
-          {t('pages.cases.results-panel.caption')}
-        </p>
-        <p className="govuk-body govuk-!-font-weight-bold">0</p>
-      </div>
-    </div>
+    <>
+      <h2 className="govuk-heading-m">{t('pages.cases.results-panel.title')}</h2>
+      <p className="govuk-body govuk-!-margin-bottom-1">{t('pages.cases.results-panel.caption')}</p>
+      <p className="govuk-body govuk-!-font-weight-bold">0</p>
+    </>
   );
 };
 


### PR DESCRIPTION
### AC
Default details panel should exist for when there is no case for the businessKey specified

### Updated
- added central section
- added titles and separator
- added results panel
- added non functioning button


### Notes
- The placeholder for businessKey text is visible so we can sign off the design - this panel normally would not show without a businessKey being clicked on/entered

### To test
- Pull and run cop-ui
- Login to cop-ui
- Navigate to the /cases page without error
- You should see the centre section with 4 titles, seperator blue lines, a copy case link button, a dropdown field in case history, an example link in case history