### PR TITLE
COP-2826 Split details into components

### DIFF
--- a/cases/CasePage.jsx
+++ b/cases/CasePage.jsx
@@ -23,7 +23,7 @@ const CasePage = () => {
             <input
               spellCheck="false"
               className="govuk-input search__input"
-              placeholder={t('pages.cases.list.search-placeholder')}
+              placeholder={t('pages.cases.search-placeholder')}
               id="bfNumber"
               name="search"
               type="text"

--- a/cases/routes.js
+++ b/cases/routes.js
@@ -7,7 +7,7 @@ const routes = mount({
   '/': map((request, context) =>
     withAuthentication(
       route({
-        title: context.t('pages.cases.list.title'),
+        title: context.t('pages.cases.title'),
         view: <CasePage />,
       })
     )

--- a/client/public/locales/en-GB/translation.json
+++ b/client/public/locales/en-GB/translation.json
@@ -135,13 +135,30 @@
       "heading": "Cases",
       "heading-help": "Enter a COP number in quotes to search for cases—e.g. \"COP-20200406-24\".",
       "heading-warning": "Please note all actions are audited.",
-      "list": {
-        "title": "Cases",
-        "search-placeholder": "Search using a COP prefixed number"
-      },
+      "search-placeholder": "Search using a COP prefixed number",
       "results-panel": {
         "title": "Search results",
         "caption": "Number of cases found"
+      },
+      "details-panel": {
+        "case-actions": {
+          "heading": "Case actions"
+        },
+        "case-attachments": {
+          "heading": "Case attachments"
+        },
+        "case-history": {
+          "heading": "Case history",
+          "select-input-order": "Order by",
+          "select-input-latest": "Latest process start date",
+          "select-input-earliest": "Earliest process start date"
+        },
+        "case-intro": {
+          "copy-button": "Copy case link"
+        },
+        "case-metrics": {
+          "heading": "Case metrics"
+        }
       }
     },
     "login": {

--- a/client/src/pages/cases/CaseDetailsPanel.jsx
+++ b/client/src/pages/cases/CaseDetailsPanel.jsx
@@ -1,68 +1,29 @@
 import React from 'react';
+import CaseActions from './components/CaseActions';
+import CaseAttachments from './components/CaseAttachments';
+import CaseHistory from './components/CaseHistory';
+import CaseIntro from './components/CaseIntro';
+import CaseMetrics from './components/CaseMetrics';
 
 const CaseDetailsPanel = () => {
   return (
     <>
       <div className="govuk-grid-row govuk-card">
-        <div className="govuk-grid-column-one-half">
-          <h2 className="govuk-heading-m">BusinessKeyHere</h2>
-        </div>
-        <div className="govuk-grid-column-one-half">
-          <button
-            type="button"
-            style={{ float: 'right' }}
-            className="govuk-button govuk-button--secondary"
-          >
-            Copy case link
-          </button>
-        </div>
+        <CaseIntro />
       </div>
       <div className="govuk-grid-row govuk-card govuk-!-margin-top-4">
-        <div className="govuk-grid-column-full">
-          <h3 className="govuk-heading-m">Case actions</h3>
-        </div>
+        <CaseActions />
       </div>
       <div className="govuk-grid-row govuk-card govuk-!-margin-top-4">
-        <div className="govuk-grid-column-full">
-          <h3 className="govuk-heading-m">Case history</h3>
-          <div className="govuk-form-group">
-            <label className="govuk-label" htmlFor="sort">
-              Order by
-              <select
-                className="govuk-select govuk-!-display-block govuk-!-margin-top-1"
-                id="sort"
-                name="sort"
-              >
-                <option value="desc">Latest process start date</option>
-                <option value="acs">Earliest process start date</option>
-              </select>
-            </label>
-          </div>
-          <div id="businessKey" className="govuk-accordion" data-module="govuk-accordion">
-            <div className="govuk-accordion__section">
-              <div className="govuk-accordion__section-header">
-                <h4 className="govuk-accordion__section-heading">
-                  <span className="govuk-accordion__section-button" id="id">
-                    example title
-                  </span>
-                </h4>
-              </div>
-            </div>
-          </div>
-        </div>
+        <CaseHistory />
       </div>
       <div className="govuk-grid-row govuk-card govuk-!-margin-top-4">
-        <div className="govuk-grid-column-full">
-          <h3 className="govuk-heading-m">Case attachments</h3>
-        </div>
+        <CaseAttachments />
       </div>
       <div className="govuk-grid-row govuk-card govuk-!-margin-top-4">
-        <div className="govuk-grid-column-full">
-          <h3 className="govuk-heading-m">Case metrics</h3>
-        </div>
+        <CaseMetrics />
       </div>
     </>
   );
 };
-
 export default CaseDetailsPanel;

--- a/client/src/pages/cases/CasePage.jsx
+++ b/client/src/pages/cases/CasePage.jsx
@@ -23,7 +23,7 @@ const CasePage = () => {
             <input
               spellCheck="false"
               className="govuk-input search__input"
-              placeholder={t('pages.cases.list.search-placeholder')}
+              placeholder={t('pages.cases.search-placeholder')}
               id="bfNumber"
               name="search"
               type="text"

--- a/client/src/pages/cases/components/CaseActions.jsx
+++ b/client/src/pages/cases/components/CaseActions.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+
+const CaseActions = () => {
+  const { t } = useTranslation();
+
+  return (
+    <>
+      <div className="govuk-grid-column-full">
+        <h3 className="govuk-heading-m">{t('pages.cases.details-panel.case-actions.heading')}</h3>
+      </div>
+    </>
+  );
+};
+export default CaseActions;

--- a/client/src/pages/cases/components/CaseAttachments.jsx
+++ b/client/src/pages/cases/components/CaseAttachments.jsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+
+const CaseAttachments = () => {
+  const { t } = useTranslation();
+
+  return (
+    <>
+      <div className="govuk-grid-column-full">
+        <h3 className="govuk-heading-m">
+          {t('pages.cases.details-panel.case-attachments.heading')}
+        </h3>
+      </div>
+    </>
+  );
+};
+export default CaseAttachments;

--- a/client/src/pages/cases/components/CaseHistory.jsx
+++ b/client/src/pages/cases/components/CaseHistory.jsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+
+const CaseHistory = () => {
+  const { t } = useTranslation();
+
+  return (
+    <>
+      <div className="govuk-grid-column-full">
+        <h3 className="govuk-heading-m">{t('pages.cases.details-panel.case-history.heading')}</h3>
+        <div className="govuk-form-group">
+          <label className="govuk-label" htmlFor="sort">
+            {t('pages.cases.details-panel.case-history.select-input-order')}
+            <select
+              className="govuk-select govuk-!-display-block govuk-!-margin-top-1"
+              id="sort"
+              name="sort"
+            >
+              <option value="desc">
+                {t('pages.cases.details-panel.case-history.select-input-latest')}
+              </option>
+              <option value="acs">
+                {t('pages.cases.details-panel.case-history.select-input-earliest')}
+              </option>
+            </select>
+          </label>
+        </div>
+        <div id="businessKey" className="govuk-accordion" data-module="govuk-accordion">
+          <div className="govuk-accordion__section">
+            <div className="govuk-accordion__section-header">
+              <h4 className="govuk-accordion__section-heading">
+                <span className="govuk-accordion__section-button" id="id" />
+              </h4>
+            </div>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+};
+export default CaseHistory;

--- a/client/src/pages/cases/components/CaseIntro.jsx
+++ b/client/src/pages/cases/components/CaseIntro.jsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+
+const CaseIntro = () => {
+  const { t } = useTranslation();
+
+  return (
+    <>
+      <div className="govuk-grid-column-one-half">
+        <h2 className="govuk-heading-m">Case</h2>
+      </div>
+      <div className="govuk-grid-column-one-half">
+        <button
+          type="button"
+          style={{ float: 'right' }}
+          className="govuk-button govuk-button--secondary"
+        >
+          {t('pages.cases.details-panel.case-intro.copy-button')}
+        </button>
+      </div>
+    </>
+  );
+};
+export default CaseIntro;

--- a/client/src/pages/cases/components/CaseMetrics.jsx
+++ b/client/src/pages/cases/components/CaseMetrics.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+
+const CaseMetrics = () => {
+  const { t } = useTranslation();
+
+  return (
+    <>
+      <div className="govuk-grid-column-full">
+        <h3 className="govuk-heading-m">{t('pages.cases.details-panel.case-metrics.heading')}</h3>
+      </div>
+    </>
+  );
+};
+export default CaseMetrics;

--- a/client/src/pages/cases/routes.js
+++ b/client/src/pages/cases/routes.js
@@ -7,7 +7,7 @@ const routes = mount({
   '/': map((request, context) =>
     withAuthentication(
       route({
-        title: context.t('pages.cases.list.title'),
+        title: context.t('pages.cases.title'),
         view: <CasePage />,
       })
     )


### PR DESCRIPTION
### AC
Default details panel should exist for when there is no case for the businessKey specified

### Updated
- moved sections to their own components
- moved content to translations.json


### Notes
- The h3 on the intro is hardcoded to 'Cases' for now, functionality will be added to make it the businessKey

### To test
- Pull and run cop-ui
- Login to cop-ui
- Navigate to the /cases page without error
- The page should still contain the case actions, history, attachment, metrics sections
- There should be no instances of `pages.cases.xxx`, all should be user friendly words