### PR TITLE
COP-3590 Add override scss for header when displaying form

### DIFF
--- a/client/src/components/form/DisplayForm.jsx
+++ b/client/src/components/form/DisplayForm.jsx
@@ -12,6 +12,7 @@ import { augmentRequest, interpolate } from '../../utils/formioSupport';
 import Logger from '../../utils/logger';
 import ApplicationSpinner from '../ApplicationSpinner';
 import FileService from '../../utils/FileService';
+import './DisplayForm.scss';
 
 Formio.use(gds);
 

--- a/client/src/components/form/DisplayForm.scss
+++ b/client/src/components/form/DisplayForm.scss
@@ -1,0 +1,7 @@
+$govuk-page-width: 1400px;
+
+@import '~govuk-frontend/govuk/all';
+
+.govuk-header__container, .govuk-width-container {
+  @include govuk-width-container(1400px);
+}


### PR DESCRIPTION
*Bug*

When viewing /forms we were seeing a narrow header, it was using the GDS 1020px version rather than the COP 1400px version. Looked to be due to the DisplayForms component.

*Updated*

Added override css for that component