### PR TITLE
COP-2837 Add NotFound error handler and test files

### DIFF
--- a/client/src/components/NotFound.jsx
+++ b/client/src/components/NotFound.jsx
@@ -1,0 +1,26 @@
+import React from 'react';
+
+const NotFound = () => {
+  return (
+    <div className="govuk-width-container">
+      <main className="govuk-main-wrapper govuk-main-wrapper--l" id="main-content" role="main">
+        <div className="govuk-grid-row">
+          <div className="govuk-grid-column-two-thirds">
+            <h1 className="govuk-heading-l">Page not found</h1>
+            <p className="govuk-body">If you typed the web address, check it is correct.</p>
+            <p className="govuk-body">
+              If you pasted the web address, check you copied the entire address or use the link to
+              direct you to the{' '}
+              <a href="/dashboard" className="govuk-link">
+                COP dashboard
+              </a>
+              .
+            </p>
+          </div>
+        </div>
+      </main>
+    </div>
+  );
+};
+
+export default NotFound;

--- a/client/src/components/NotFound.test.jsx
+++ b/client/src/components/NotFound.test.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import NotFound from './NotFound';
+
+describe('Not Found page', () => {
+  it('renders without crashing', () => {
+    const wrapper = shallow(<NotFound />);
+    expect(wrapper.exists()).toBe(true);
+  });
+});

--- a/client/src/components/layout/index.jsx
+++ b/client/src/components/layout/index.jsx
@@ -9,37 +9,44 @@ import Footer from '../footer';
 import Logger from '../../utils/logger';
 import AlertBanner from '../alert/AlertBanner';
 import { AlertContextProvider } from '../../utils/AlertContext';
+import NotFound from '../NotFound';
 
-const ErrorFallback = ({ resetErrorBoundary }) => {
+const ErrorFallback = ({ resetErrorBoundary, error }) => {
   const { t } = useTranslation();
-  return (
-    <div
-      className="govuk-width-container govuk-error-summary govuk-!-margin-top-5"
-      aria-labelledby="error-summary-title"
-      role="alert"
-      tabIndex="-1"
-      data-module="govuk-error-summary"
-    >
-      <h2 className="govuk-error-summary__title" id="error-summary-title">
-        {t('render.error.title')}
-      </h2>
-      <div className="govuk-error-summary__body">
-        <button
-          type="button"
-          className="govuk-button govuk-button--warning"
-          data-module="govuk-button"
-          onClick={resetErrorBoundary}
-        >
-          {t('render.error.retry')}
-        </button>
+
+  if (error.status === 404) {
+    return <NotFound />;
+  } 
+    return (
+      <div
+        className="govuk-width-container govuk-error-summary govuk-!-margin-top-5"
+        aria-labelledby="error-summary-title"
+        role="alert"
+        tabIndex="-1"
+        data-module="govuk-error-summary"
+      >
+        <h2 className="govuk-error-summary__title" id="error-summary-title">
+          {t('render.error.title')}
+        </h2>
+        <div className="govuk-error-summary__body">
+          <button
+            type="button"
+            className="govuk-button govuk-button--warning"
+            data-module="govuk-button"
+            onClick={resetErrorBoundary}
+          >
+            {t('render.error.retry')}
+          </button>
+        </div>
       </div>
-    </div>
-  );
+    );
+  
 };
 
 ErrorFallback.propTypes = {
   error: PropTypes.shape({
     message: PropTypes.string.isRequired,
+    status: PropTypes.number.isRequired,
   }).isRequired,
   resetErrorBoundary: PropTypes.func.isRequired,
 };
@@ -55,6 +62,7 @@ const Layout = ({ children }) => {
       <div className="app-container">
         <ErrorBoundary
           FallbackComponent={ErrorFallback}
+          error
           onError={(error, componentStack) => {
             Logger.error({
               token: keycloak.token,

--- a/client/src/components/layout/index.test.jsx
+++ b/client/src/components/layout/index.test.jsx
@@ -3,6 +3,7 @@ import { shallow, mount } from 'enzyme';
 import Layout from './index';
 import Logger from '../../utils/logger';
 import { mockGoBack } from '../../setupTests';
+import NotFound from '../NotFound';
 
 jest.mock('../../utils/logger', () => ({
   error: jest.fn(),
@@ -37,6 +38,24 @@ describe('Layout', () => {
 
     const alert = wrapper.find('.govuk-error-summary__body').at(0);
     alert.find('button').at(0).simulate('click');
+  });
+
+  it('can render page not found when error is 404', async () => {
+    const ErrorComponent = () => {
+      const error = new Error('Failed');
+      error.status = 404;
+      throw error;
+    };
+
+    const wrapper = await mount(
+      <Layout>
+        <ErrorComponent />
+      </Layout>
+    );
+
+    expect(wrapper.find(NotFound).length).toBe(1);
+    expect(console.error).toBeCalled();
+    expect(Logger.error).toBeCalled();
   });
 
   it('can click on back button', () => {


### PR DESCRIPTION
### AC
If page is not found, a Not Found page should be rendered and should link towards the dashboard

### Updated
- Added a `NotFound.jsx` component to render when a 404 occurs
- `ErrorFallBack` in `layout/index.jsx` now takes an error object which contains the error code. `ErrorFallBack` now renders component conditionally based on the error code, currently it only renders a specific component for a 404.
- Added barebones test file for `NotFound.jsx`
- Added test in `layout/index.jsx` to check NotFound is rendered when 404 is present and not just render a generic error message

### Notes
- The content of the `NotFound.jsx` component needs reviewing, for now, it closely follows the government template
- This is just one part of the ticket, further logic needs to be added for other error cases

### To test
- Pull and run a build with gradle in cop-ui directory
- Run cop-ui local with new build
- Login to cop-ui
- From the dashboard, after the `/dashboard` in the url add `/ThisIsNotAPage`
- Repeat this for `/forms`, `/reports`, `/cases` and `/tasks`
- You should see a `Page Not Found` message being rendered 
- When clicking on the dashboard link provided, you should be taken back to `/dashboard` without error