### PR TITLE
COP-3591 Fix header on tasks

### DIFF
--- a/client/src/components/form/DisplayForm.scss
+++ b/client/src/components/form/DisplayForm.scss
@@ -1,3 +1,7 @@
 $govuk-page-width: 1400px;
 
 @import '~govuk-frontend/govuk/all';
+
+.govuk-header__container, .govuk-width-container {
+  @include govuk-width-container($govuk-page-width);
+}

--- a/client/src/components/form/DisplayForm.scss
+++ b/client/src/components/form/DisplayForm.scss
@@ -1,7 +1,3 @@
 $govuk-page-width: 1400px;
 
 @import '~govuk-frontend/govuk/all';
-
-.govuk-header__container, .govuk-width-container {
-  @include govuk-width-container(1400px);
-}

--- a/client/src/pages/tasks/components/TaskList.scss
+++ b/client/src/pages/tasks/components/TaskList.scss
@@ -1,3 +1,5 @@
+$govuk-page-width: 1400px;
+
 @import '~govuk-frontend/govuk/all';
 
 .app-task-list {


### PR DESCRIPTION
### AC
Header is correctly formatted on the /tasks page

### Updated
- Defined the govuk-page-width variable at the top of the TaskList.scss file and set it to 1400px
- Changed fix value in DisplayForm.scss to govuk-page-width variable