### PR TITLE
COP-2819 Add Cases box

### DIFF
--- a/client/public/locales/en-GB/translation.json
+++ b/client/public/locales/en-GB/translation.json
@@ -67,6 +67,10 @@
         "tasks": {
           "title": "Tasks",
           "footer": "Claim a task assigned to you or your groups"
+        },
+        "cases": {
+          "title": "Cases",
+          "footer": "View active or closed cases"
         }
       }
     },

--- a/client/public/locales/en-GB/translation.json
+++ b/client/public/locales/en-GB/translation.json
@@ -65,7 +65,7 @@
           "footer": "View operational reports"
         },
         "tasks": {
-          "title": "Tasks",
+          "title": "Tasks assigned",
           "footer": "Claim a task assigned to you or your groups"
         },
         "cases": {

--- a/client/src/pages/home/components/Card.jsx
+++ b/client/src/pages/home/components/Card.jsx
@@ -5,29 +5,41 @@ import { useTranslation } from 'react-i18next';
 
 const Card = ({ count, footer, handleClick, href, isLoading, title }) => {
   const { t } = useTranslation();
-  const heading = count === 1 ? title.slice(0, -1) : title;
+  const renderTitle = () => {
+    if (count === null) {
+      return (
+        <h2 id="title" className="govuk-!-font-size-36 govuk-!-font-weight-bold">
+          {title}
+        </h2>
+      );
+    }
+    return (
+      <>
+        <h2 id="count" className="govuk-!-font-size-48 govuk-!-font-weight-bold">
+          {count}
+        </h2>
+        <span className="govuk-!-font-size-19 govuk-!-font-weight-bold">{title}</span>
+      </>
+    );
+  };
   return (
-    <div className="govuk-grid-row">
-      <div className="govuk-grid-column-full __card">
-        <a
-          href={href}
-          onClick={(e) => {
-            e.preventDefault();
-            handleClick();
-          }}
-          className="card__body"
-        >
-          {isLoading ? (
-            <span className="govuk-!-font-size-19 govuk-!-font-weight-bold">{t('loading')}</span>
-          ) : (
-            <h2 className="govuk-!-font-size-36 govuk-!-font-weight-bold">
-              {count === null ? heading : `${count} ${heading}`}
-            </h2>
-          )}
-        </a>
-        <div className="card__footer">
-          <p className="govuk-body">{footer}</p>
-        </div>
+    <div className="__card govuk-grid-column-one-third">
+      <a
+        href={href}
+        onClick={(e) => {
+          e.preventDefault();
+          handleClick();
+        }}
+        className="card__body"
+      >
+        {isLoading ? (
+          <span className="govuk-!-font-size-19 govuk-!-font-weight-bold">{t('loading')}</span>
+        ) : (
+          renderTitle()
+        )}
+      </a>
+      <div className="card__footer">
+        <p className="govuk-!-font-size-19">{footer}</p>
       </div>
     </div>
   );
@@ -35,10 +47,11 @@ const Card = ({ count, footer, handleClick, href, isLoading, title }) => {
 
 Card.defaultProps = {
   count: null,
+  isLoading: false,
 };
 
 Card.propTypes = {
-  isLoading: PropTypes.bool.isRequired,
+  isLoading: PropTypes.bool,
   count: PropTypes.number,
   href: PropTypes.string.isRequired,
   handleClick: PropTypes.func.isRequired,

--- a/client/src/pages/home/index.jsx
+++ b/client/src/pages/home/index.jsx
@@ -13,11 +13,6 @@ const Home = () => {
 
   const axiosInstance = useAxios();
 
-  const [formsCount, setFormsCount] = useState({
-    isLoading: true,
-    count: 0,
-  });
-
   const [tasksCount, setTasksCount] = useState({
     isLoading: true,
     count: 0,
@@ -26,32 +21,6 @@ const Home = () => {
   useEffect(() => {
     const source = axios.CancelToken.source();
     if (axiosInstance) {
-      axiosInstance
-        .get('/camunda/engine-rest/process-definition/count', {
-          cancelToken: source.token,
-          params: {
-            startableInTasklist: true,
-            latestVersion: true,
-            active: true,
-          },
-        })
-        .then((response) => {
-          if (isMounted.current) {
-            setFormsCount({
-              isLoading: false,
-              count: response.data.count,
-            });
-          }
-        })
-        .catch(() => {
-          if (isMounted.current) {
-            setFormsCount({
-              isLoading: false,
-              count: 0,
-            });
-          }
-        });
-
       axiosInstance({
         method: 'POST',
         url: '/camunda/engine-rest/task/count',
@@ -88,7 +57,6 @@ const Home = () => {
     };
   }, [
     axiosInstance,
-    setFormsCount,
     setTasksCount,
     isMounted,
     keycloak.tokenParsed.groups,
@@ -104,41 +72,54 @@ const Home = () => {
         </div>
       </div>
       <div className="govuk-grid-row">
-        <div className="govuk-grid-column-one-half">
-          <Card
-            title={t('pages.home.card.forms.title')}
-            href="/forms"
-            isLoading={formsCount.isLoading}
-            count={formsCount.count}
-            handleClick={async () => {
-              await navigation.navigate('/forms');
-            }}
-            footer={t('pages.home.card.forms.footer')}
-          />
-        </div>
-        <div className="govuk-grid-column-one-half">
-          <Card
-            title={t('pages.home.card.tasks.title')}
-            href="/tasks"
-            count={tasksCount.count}
-            isLoading={tasksCount.isLoading}
-            handleClick={async () => {
-              await navigation.navigate('/tasks');
-            }}
-            footer={t('pages.home.card.tasks.footer')}
-          />
-        </div>
-        <div className="govuk-grid-column-one-half">
-          <Card
-            title={t('pages.home.card.reports.title')}
-            href="/reports"
-            isLoading={tasksCount.isLoading}
-            handleClick={async () => {
-              await navigation.navigate('/reports');
-            }}
-            footer={t('pages.home.card.reports.footer')}
-          />
-        </div>
+        <ul className="govuk-list">
+          <li>
+            <Card
+              title={t('pages.home.card.tasks.title')}
+              href="/tasks"
+              count={tasksCount.count}
+              isLoading={tasksCount.isLoading}
+              handleClick={async () => {
+                await navigation.navigate('/tasks');
+              }}
+              footer={t('pages.home.card.tasks.footer')}
+            />
+          </li>
+        </ul>
+      </div>
+      <div className="govuk-grid-row">
+        <ul className="govuk-list">
+          <li>
+            <Card
+              href="/forms"
+              handleClick={async () => {
+                await navigation.navigate('/forms');
+              }}
+              footer={t('pages.home.card.forms.footer')}
+              title={t('pages.home.card.forms.title')}
+            />
+          </li>
+          <li>
+            <Card
+              title={t('pages.home.card.cases.title')}
+              href="/cases"
+              handleClick={async () => {
+                await navigation.navigate('/cases');
+              }}
+              footer={t('pages.home.card.cases.footer')}
+            />
+          </li>
+          <li>
+            <Card
+              title={t('pages.home.card.reports.title')}
+              href="/reports"
+              handleClick={async () => {
+                await navigation.navigate('/reports');
+              }}
+              footer={t('pages.home.card.reports.footer')}
+            />
+          </li>
+        </ul>
       </div>
     </div>
   );

--- a/client/src/pages/home/index.test.jsx
+++ b/client/src/pages/home/index.test.jsx
@@ -17,11 +17,7 @@ describe('Home', () => {
     shallow(<Home />);
   });
 
-  it('renders forms, tasks and reports panels', async () => {
-    mockAxios.onGet('/camunda/engine-rest/process-definition/count').reply(200, {
-      count: 10,
-    });
-
+  it('renders forms, tasks, cases and reports panels', async () => {
     mockAxios.onPost('/camunda/engine-rest/task/count').reply(200, {
       count: 10,
     });
@@ -34,19 +30,19 @@ describe('Home', () => {
       await wrapper.update();
     });
 
-    expect(wrapper.find(Card).length).toBe(3);
-    const formsCard = wrapper.find(Card).at(0);
-    const tasksCard = wrapper.find(Card).at(1);
-    const reportsCard = wrapper.find(Card).at(2);
+    expect(wrapper.find(Card).length).toBe(4);
+    const tasksCard = wrapper.find(Card).at(0);
+    const formsCard = wrapper.find(Card).at(1);
+    const casesCard = wrapper.find(Card).at(2);
+    const reportsCard = wrapper.find(Card).at(3);
 
-    expect(formsCard.find('h2').text()).toBe('10 pages.home.card.forms.title');
-    expect(tasksCard.find('h2').text()).toBe('10 pages.home.card.tasks.title');
+    expect(formsCard.find('h2').text()).toBe('pages.home.card.forms.title');
+    expect(tasksCard.find('h2').text()).toBe('10');
     expect(reportsCard.find('h2').text()).toBe('pages.home.card.reports.title');
+    expect(casesCard.find('h2').text()).toBe('pages.home.card.cases.title');
   });
 
   it('handles errors and sets it to zero', async () => {
-    mockAxios.onGet('/camunda/engine-rest/process-definition/count').reply(500, {});
-
     mockAxios.onPost('/camunda/engine-rest/task/count').reply(500, {});
 
     const wrapper = mount(<Home />);
@@ -57,21 +53,19 @@ describe('Home', () => {
       await wrapper.update();
     });
 
-    expect(wrapper.find(Card).length).toBe(3);
-    const formsCard = wrapper.find(Card).at(0);
-    const tasksCard = wrapper.find(Card).at(1);
-    const reportsCard = wrapper.find(Card).at(2);
+    expect(wrapper.find(Card).length).toBe(4);
+    const tasksCard = wrapper.find(Card).at(0);
+    const formsCard = wrapper.find(Card).at(1);
+    const casesCard = wrapper.find(Card).at(2);
+    const reportsCard = wrapper.find(Card).at(3);
 
-    expect(formsCard.find('h2').text()).toBe('0 pages.home.card.forms.title');
-    expect(tasksCard.find('h2').text()).toBe('0 pages.home.card.tasks.title');
+    expect(formsCard.find('h2').text()).toBe('pages.home.card.forms.title');
+    expect(tasksCard.find('h2').text()).toBe('0');
     expect(reportsCard.find('h2').text()).toBe('pages.home.card.reports.title');
+    expect(casesCard.find('h2').text()).toBe('pages.home.card.cases.title');
   });
 
   it('can handle onClick', async () => {
-    mockAxios.onGet('/camunda/engine-rest/process-definition/count').reply(200, {
-      count: 10,
-    });
-
     mockAxios.onPost('/camunda/engine-rest/task/count').reply(200, {
       count: 10,
     });
@@ -83,9 +77,11 @@ describe('Home', () => {
       await wrapper.update();
     });
 
-    const formsCard = wrapper.find(Card).at(0);
-    const tasksCard = wrapper.find(Card).at(1);
-    const reportsCard = wrapper.find(Card).at(2);
+    expect(wrapper.find(Card).length).toBe(4);
+    const tasksCard = wrapper.find(Card).at(0);
+    const formsCard = wrapper.find(Card).at(1);
+    const casesCard = wrapper.find(Card).at(2);
+    const reportsCard = wrapper.find(Card).at(3);
 
     formsCard.props().handleClick();
     expect(mockNavigate).toBeCalledWith('/forms');
@@ -95,5 +91,8 @@ describe('Home', () => {
 
     reportsCard.props().handleClick();
     expect(mockNavigate).toBeCalledWith('/reports');
+
+    casesCard.props().handleClick();
+    expect(mockNavigate).toBeCalledWith('/cases');
   });
 });


### PR DESCRIPTION
### AC
User should be able to click on a cases panel on the dashboard that takes them to the /cases url

### Updated
- Updated translation.json to contain content for cases
- Card title rendering now includes a condition to check if there is both a count and title to display, if so then render both items accordingly. If this this combination is not present then only render the title provided (Forms, Cases, Reports)
- Added default values for Card props that are now not required to be passed down, this is done to allow for the conditional check mentioned above.
- Removed axios call in home/index.jsx that returns the number of forms available to the user, this is does not appear on COP on the dashboard and so has been removed.
- Changed jsx in home/index.jsx to be in accordance with the existing cop's ui, specifically, making the panels be 1/3 of their container and placing each row of panels in an unordered list
- Added tests for the cases panel
- Removed assertions in index.test.jsx that check for the count of forms being rendered on the dashboard. This is not a desired feature of COP.

### Notes
- The `renderTitle` function in the `Card.jsx` file is used in order to achieve identical formatting to COPv1 UI. The main title for each panel is not consistent and depends on whether a count is present. In order to simplify this, I decided to conditionally render 2 types of panel headers each with their respective font size and format.

### To test
*COP UI localhost:*
- Pull and run cop-ui on localhost
- Login to cop-ui
- Click the 'Cases' panel
- You should be navigated to the /cases page without error

*COP UI local:*
- Pull and run cop-ui local with new gradle build
- Login to cop-ui
- Click the 'Cases' panel
- You should be navigated to the /cases page without error