### PR TITLE
Add initiatedBy variable to track user email who submitted the form

### DIFF
--- a/client/src/pages/forms/hooks.js
+++ b/client/src/pages/forms/hooks.js
@@ -18,6 +18,10 @@ export default () => {
             value: JSON.stringify(submission.data),
             type: 'json',
           },
+          initiatedBy: {
+            value: submission.data.form.submittedBy,
+            type: 'string',
+          },
         };
         axiosInstance
           .post(`/camunda/engine-rest/process-definition/key/${id}/submit-form`, {

--- a/client/src/pages/forms/hooks.test.jsx
+++ b/client/src/pages/forms/hooks.test.jsx
@@ -25,6 +25,9 @@ describe('hooks', () => {
         {
           data: {
             test: 'test',
+            form: {
+              submittedBy: 'test@digital.homeoffice.gov.uk',
+            },
           },
         },
         {
@@ -52,6 +55,9 @@ describe('hooks', () => {
         {
           data: {
             test: 'test',
+            form: {
+              submittedBy: 'test@digital.homeoffice.gov.uk',
+            },
           },
         },
         {


### PR DESCRIPTION
### AC
User should be able to click on a cases panel on the dashboard that takes them to the /cases url

### Updated
- Added `initiatedBy` as a variable to the `submit` function for forms
- set value to be the email address of the submitting user

### Notes
- Our BPMNs use `initatedBy` to assign the task
- As our BPMNs/Forms currently use shift and staff details that are unavailable at the moment, you can currently only test this with a flow that does not require them (negative border event)

### To test

*COP UI local:*
- Remove the `group` from collect-event-at-border.bpmn negative element (it uses shiftDetails which does not exist)
- Pull and run cop-ui local with new gradle build
- Login to cop-ui
- Submit a `record-border-event` `negative` flow
- It should submit without error