### PR TITLE
COP-3613 Add page title for forms

### DIFF
--- a/client/src/pages/forms/FormPage.test.jsx
+++ b/client/src/pages/forms/FormPage.test.jsx
@@ -81,7 +81,7 @@ describe('FormPage', () => {
       await wrapper.update();
     });
     expect(wrapper.find(ApplicationSpinner).exists()).toBe(false);
-    expect(mockAxios.history.get.length).toBe(1);
+    expect(mockAxios.history.get.length).toBe(2); // call to set formPageTitle, call to loadForm
   });
 
   it('can submit the form', async () => {


### PR DESCRIPTION
**AC**

Forms should have a page title (based off the `name` in the data, which is set in the related BPMN. This goes above the form's steps.

**Updated**

Added API call to get the `name` and set it as the `<h1>`

**To test**

- click on `record border event` form
- you should see
 - Page Title: `Collect event at border`
 - Form Title: `Record the details of a border event`
 