### PR TITLE
COP-3722 Content

### DIFF
--- a/client/public/locales/en-GB/translation.json
+++ b/client/public/locales/en-GB/translation.json
@@ -118,6 +118,10 @@
           "title": "Forms",
           "footer": "Submit a form"
         },
+        "group-tasks": {
+          "title": "tasks assigned to your team",
+          "footer": "Overall tasks assigned to your team"
+        },
         "reports": {
           "title": "Reports",
           "footer": "View operational reports"
@@ -166,6 +170,12 @@
         "heading": "{{count}} tasks assigned to you",
         "status": "Open",
         "title": "Your tasks | Central Operations Platform"
+      },
+      "groups": {
+        "caption": "Your team's tasks",
+        "heading": "{{count}} tasks assigned to your team",
+        "status": "Open",
+        "title": "Your team's tasks | Central Operations Platform"
       }
     }
   }

--- a/client/public/locales/en-GB/translation.json
+++ b/client/public/locales/en-GB/translation.json
@@ -161,12 +161,11 @@
       "unassigned": "Unassigned"
     },
     "tasks": {
-      "title": "Your tasks",
-      "list": {
+      "yours": {
+        "caption": "Your tasks",
+        "heading": "{{count}} tasks assigned to you",
         "status": "Open",
-        "heading": "Your tasks",
-        "title": "Your tasks | Central Operations Platform",
-        "size": "{{count}} tasks assigned to you"
+        "title": "Your tasks | Central Operations Platform"
       }
     }
   }

--- a/client/public/locales/en-GB/translation.json
+++ b/client/public/locales/en-GB/translation.json
@@ -2,10 +2,10 @@
   "keycloak": {
     "initialising": "Initialising single sign on"
   },
-  "warning": "Warning",
   "back": "Back",
   "loading": "Loading...",
   "submitting": "Submitting your form....",
+  "warning": "Warning",
   "error": {
     "details": "Error details",
     "title": "We are experiencing technical problems",
@@ -50,90 +50,6 @@
     "accessibility": {
       "title": "Accessibility Statement | Central Operations Platform"
     },
-    "privacy": {
-      "title": "Privacy and Cookie Policy | Central Operations Platform"
-    },
-    "home": {
-      "title": "Central Operations Platform",
-      "heading": "Operational dashboard",
-      "card": {
-        "forms": {
-          "title": "Forms",
-          "footer": "Submit a form"
-        },
-        "reports": {
-          "title": "Reports",
-          "footer": "View operational reports"
-        },
-        "tasks": {
-          "title": "Tasks assigned",
-          "footer": "Claim a task assigned to you or your groups"
-        },
-        "cases": {
-          "title": "Cases",
-          "footer": "View active or closed cases"
-        }
-      }
-    },
-    "form": {
-      "title": "Form | Central Operations Platform",
-      "submission": {
-        "success-message": "Your form was successfully submitted",
-        "your-reference": "Your reference is {{reference}}",
-        "close": "Close confirmation"
-      },
-      "error": {
-        "form": {
-          "title": "There is a problem with your form"
-        }
-      }
-    },
-    "forms": {
-      "list": {
-        "heading": "Operational forms",
-        "size": "{{count}} forms",
-        "title": "Operational forms | Central Operations Platform",
-        "load-more": "Load more",
-        "search": "Search for a form",
-        "search-placeholder": "Search form name",
-        "search-hint": "Must be greater than 3 characters"
-      }
-    },
-    "report": {
-      "title": "Report | Central Operations Platform"
-    },
-    "reports": {
-      "list": {
-        "heading": "Operational reports",
-        "size": "{{count}} reports",
-        "title": "Operational reports | Central Operations Platform"
-      }
-    },
-    "task": {
-      "submission": {
-        "success-message": "You have successfully completed the task"
-      },
-      "actions": {
-        "complete": "Complete"
-      },
-      "no-form": "There is no form associated with this task",
-      "title": "Task",
-      "category": "Category",
-      "due": "Due",
-      "priority": "Priority",
-      "assignee": "Assignee",
-      "current-assignee": "You are the current assignee",
-      "unassigned": "Unassigned"
-    },
-    "tasks": {
-      "title": "Tasks",
-      "list": {
-        "status": "Open",
-        "heading": "Tasks",
-        "title": "Tasks to complete",
-        "size": "{{count}} tasks assigned to you"
-      }
-    },
     "cases": {
       "title": "Cases",
       "caption": "Case view",
@@ -166,8 +82,92 @@
         }
       }
     },
+    "form": {
+      "title": "Form | Central Operations Platform",
+      "submission": {
+        "success-message": "Your form was successfully submitted",
+        "your-reference": "Your reference is {{reference}}",
+        "close": "Close confirmation"
+      },
+      "error": {
+        "form": {
+          "title": "There is a problem with your form"
+        }
+      }
+    },
+    "forms": {
+      "list": {
+        "heading": "Operational forms",
+        "size": "{{count}} forms",
+        "title": "Operational forms | Central Operations Platform",
+        "load-more": "Load more",
+        "search": "Search for a form",
+        "search-placeholder": "Search form name",
+        "search-hint": "Must be greater than 3 characters"
+      }
+    },
+    "home": {
+      "title": "Central Operations Platform",
+      "heading": "Operational dashboard",
+      "card": {
+        "cases": {
+          "title": "Cases",
+          "footer": "View active or closed cases"
+        },
+        "forms": {
+          "title": "Forms",
+          "footer": "Submit a form"
+        },
+        "reports": {
+          "title": "Reports",
+          "footer": "View operational reports"
+        },
+        "tasks": {
+          "title": "tasks assigned to you",
+          "footer": "Tasks assigned to you"
+        }
+      }
+    },
     "login": {
       "title": "Login"
+    },
+    "privacy": {
+      "title": "Privacy and Cookie Policy | Central Operations Platform"
+    },
+    "report": {
+      "title": "Report | Central Operations Platform"
+    },
+    "reports": {
+      "list": {
+        "heading": "Operational reports",
+        "size": "{{count}} reports",
+        "title": "Operational reports | Central Operations Platform"
+      }
+    },
+    "task": {
+      "submission": {
+        "success-message": "You have successfully completed the task"
+      },
+      "actions": {
+        "complete": "Complete"
+      },
+      "no-form": "There is no form associated with this task",
+      "title": "Task",
+      "category": "Category",
+      "due": "Due",
+      "priority": "Priority",
+      "assignee": "Assignee",
+      "current-assignee": "You are the current assignee",
+      "unassigned": "Unassigned"
+    },
+    "tasks": {
+      "title": "Your tasks",
+      "list": {
+        "status": "Open",
+        "heading": "Your tasks",
+        "title": "Your tasks | Central Operations Platform",
+        "size": "{{count}} tasks assigned to you"
+      }
     }
   }
 }

--- a/client/public/locales/en-GB/translation.json
+++ b/client/public/locales/en-GB/translation.json
@@ -7,18 +7,18 @@
   "submitting": "Submitting your form....",
   "warning": "Warning",
   "error": {
-    "details": "Error details",
-    "title": "We are experiencing technical problems",
-    "409": "The form has already been submitted",
-    "401/403": "Unable to complete your request due to authorization issues.",
-    "400": "Unable to complete your request due to form submission issues.",
-    "50x": "Internal system error",
-    "contact-support-prefix": "Please",
-    "contact-support-link-text": "contact support",
-    "error-info": "URL {{path}} - Code: {{status}}"
-  },
-  "render": {
-    "error": {
+    "api": {
+      "details": "Error details",
+      "title": "We are experiencing technical problems",
+      "409": "The form has already been submitted",
+      "401/403": "Unable to complete your request due to authorization issues.",
+      "400": "Unable to complete your request due to form submission issues.",
+      "50x": "Internal system error",
+      "contact-support-prefix": "Please",
+      "contact-support-link-text": "contact support",
+      "error-info": "URL {{path}} - Code: {{status}}"
+    },
+    "page": {
       "title": "An exception occurred",
       "description": "Please contact support",
       "retry": "Retry operation"

--- a/client/src/components/NotFound.jsx
+++ b/client/src/components/NotFound.jsx
@@ -9,12 +9,12 @@ const NotFound = () => {
       <main className="govuk-main-wrapper govuk-main-wrapper--l" id="main-content" role="main">
         <div className="govuk-grid-row">
           <div className="govuk-grid-column-two-thirds">
-            <h1 className="govuk-heading-l">{t('render.page-not-found.title')}</h1>
-            <p className="govuk-body">{t('render.page-not-found.check-address')}</p>
+            <h1 className="govuk-heading-l">{t('error.page-not-found.title')}</h1>
+            <p className="govuk-body">{t('error.page-not-found.check-address')}</p>
             <p className="govuk-body">
-              {t('render.page-not-found.paste-address')}{' '}
+              {t('error.page-not-found.paste-address')}{' '}
               <Link href="/" className="govuk-link">
-                {t('render.page-not-found.redirect-link')}
+                {t('error.page-not-found.redirect-link')}
               </Link>
               .
             </p>

--- a/client/src/components/__snapshots__/NotFound.test.jsx.snap
+++ b/client/src/components/__snapshots__/NotFound.test.jsx.snap
@@ -18,23 +18,23 @@ exports[`Not Found page matches snapshot 1`] = `
         <h1
           className="govuk-heading-l"
         >
-          render.page-not-found.title
+          error.page-not-found.title
         </h1>
         <p
           className="govuk-body"
         >
-          render.page-not-found.check-address
+          error.page-not-found.check-address
         </p>
         <p
           className="govuk-body"
         >
-          render.page-not-found.paste-address
+          error.page-not-found.paste-address
            
           <Link
             className="govuk-link"
             href="/"
           >
-            render.page-not-found.redirect-link
+            error.page-not-found.redirect-link
           </Link>
           .
         </p>

--- a/client/src/components/alert/ApiErrorAlert.jsx
+++ b/client/src/components/alert/ApiErrorAlert.jsx
@@ -16,26 +16,24 @@ const ApiErrorAlert = ({ errors }) => {
     let errorMessage;
     switch (status) {
       case 409:
-        errorMessage = t('error.409');
+        errorMessage = t('error.api.409');
         break;
       case 404:
         errorMessage = `${message}`;
         break;
       case 401:
       case 403:
-        errorMessage = t('error.401/403');
+        errorMessage = t('error.api.401/403');
         break;
       case 400:
-        errorMessage = t('error.400');
+        errorMessage = t('error.api.400');
         break;
       default:
-        errorMessage = t('error.50x');
+        errorMessage = t('error.api.50x');
     }
     return (
       <li key={uuidv4()}>
-        <p className="govuk-error-message">
-          {errorMessage}
-        </p>
+        <p className="govuk-error-message">{errorMessage}</p>
       </li>
     );
   };
@@ -49,33 +47,33 @@ const ApiErrorAlert = ({ errors }) => {
       data-module="govuk-error-summary"
     >
       <h1 className="govuk-error-summary__title" id="error-summary-title">
-        {t('error.title')}
+        {t('error.api.title')}
       </h1>
       <div className="govuk-error-summary__body">
         <ul className="govuk-list govuk-error-summary__list">{errors.map(buildMessage)}</ul>
       </div>
       <p className="govuk-body">
-        {t('error.contact-support-prefix')}{' '}
+        {t('error.api.contact-support-prefix')}{' '}
         <a
           className="govuk-link"
           rel="noopener noreferrer"
           target="_blank"
           href={config.get('serviceDeskUrl')}
         >
-          {t('error.contact-support-link-text')}
+          {t('error.api.contact-support-link-text')}
         </a>
         .
       </p>
       <details className="govuk-details">
         <summary className="govuk-details__summary">
-          <span className="govuk-details__summary-text">{t('error.details')}</span>
+          <span className="govuk-details__summary-text">{t('error.api.details')}</span>
         </summary>
         <div className="govuk-details__text">
           <div className="govuk-error-summary__body">
             <ul className="govuk-list govuk-list--bullet govuk-error-summary__list">
               {errors.map((error) => {
                 const { path, status } = error;
-                return <li key={uuidv4()}>{t('error.error-info', { path, status })}</li>;
+                return <li key={uuidv4()}>{t('error.api.error-info', { path, status })}</li>;
               })}
             </ul>
           </div>

--- a/client/src/components/layout/index.jsx
+++ b/client/src/components/layout/index.jsx
@@ -23,7 +23,7 @@ const ErrorFallback = ({ resetErrorBoundary }) => {
       data-module="govuk-error-summary"
     >
       <h2 id="error-summary-title" className="govuk-error-summary__title">
-        {t('render.error.title')}
+        {t('error.page.title')}
       </h2>
       <div className="govuk-error-summary__body">
         <button

--- a/client/src/components/layout/index.jsx
+++ b/client/src/components/layout/index.jsx
@@ -32,7 +32,7 @@ const ErrorFallback = ({ resetErrorBoundary }) => {
           data-module="govuk-button"
           onClick={resetErrorBoundary}
         >
-          {t('render.error.retry')}
+          {t('error.page.retry')}
         </button>
       </div>
     </div>

--- a/client/src/pages/tasks/TasksListPage.jsx
+++ b/client/src/pages/tasks/TasksListPage.jsx
@@ -132,8 +132,10 @@ const TasksListPage = () => {
     <>
       <div className="govuk-grid-row">
         <div className="govuk-grid-column-two-thirds">
-          <span className="govuk-caption-l">{t('pages.tasks.list.size', { count: data.total })}</span>
-          <h1 className="govuk-heading-l">{t('pages.tasks.list.heading')}</h1>
+          <span className="govuk-caption-l">{t('pages.tasks.yours.caption')}</span>
+          <h1 className="govuk-heading-l">
+            {t('pages.tasks.yours.heading', { count: data.total })}
+          </h1>
         </div>
       </div>
       <div className="govuk-grid-row">

--- a/client/src/pages/tasks/routes.js
+++ b/client/src/pages/tasks/routes.js
@@ -8,7 +8,7 @@ const routes = mount({
   '/': map((request, context) =>
     withAuthentication(
       route({
-        title: context.t('pages.tasks.list.title'),
+        title: context.t('pages.tasks.yours.title'),
         view: <TasksListPage />,
       })
     )
@@ -16,7 +16,7 @@ const routes = mount({
   '/:taskId': map((request, context) =>
     withAuthentication(
       route({
-        title: context.t('pages.task.title'),
+        title: context.t('pages.task.yours.title'),
         view: <TaskPage taskId={request.params.taskId} />,
       })
     )


### PR DESCRIPTION
**Updated**
- move object keys to be ordered by common, then pages by alphabetical
- update tasks keys and wording to match what we use in v1
- add group tasks keys and wording

**To test**
- open cop-ui
- click through pages
>- there should be no instances of text looking like `task.list.heading`
>- all titles should be readable
>- task box on dashboard and /tasks should match what is seen in cop v1