### PR TITLE
COP-3722 Add group tasks to dashboard and create list page for your tasks

### DIFF
--- a/client/src/pages/home/index.jsx
+++ b/client/src/pages/home/index.jsx
@@ -76,11 +76,11 @@ const Home = () => {
           <li>
             <Card
               title={t('pages.home.card.tasks.title')}
-              href="/tasks/yours"
+              href="/tasks/your-tasks"
               count={tasksCount.count}
               isLoading={tasksCount.isLoading}
               handleClick={async () => {
-                await navigation.navigate('/tasks/yours');
+                await navigation.navigate('/tasks/your-tasks');
               }}
               footer={t('pages.home.card.tasks.footer')}
             />

--- a/client/src/pages/home/index.jsx
+++ b/client/src/pages/home/index.jsx
@@ -76,13 +76,25 @@ const Home = () => {
           <li>
             <Card
               title={t('pages.home.card.tasks.title')}
+              href="/tasks/yours"
+              count={tasksCount.count}
+              isLoading={tasksCount.isLoading}
+              handleClick={async () => {
+                await navigation.navigate('/tasks/yours');
+              }}
+              footer={t('pages.home.card.tasks.footer')}
+            />
+          </li>
+          <li>
+            <Card
+              title={t('pages.home.card.group-tasks.title')}
               href="/tasks"
               count={tasksCount.count}
               isLoading={tasksCount.isLoading}
               handleClick={async () => {
                 await navigation.navigate('/tasks');
               }}
-              footer={t('pages.home.card.tasks.footer')}
+              footer={t('pages.home.card.group-tasks.footer')}
             />
           </li>
         </ul>

--- a/client/src/pages/home/index.test.jsx
+++ b/client/src/pages/home/index.test.jsx
@@ -30,16 +30,20 @@ describe('Home', () => {
       await wrapper.update();
     });
 
-    expect(wrapper.find(Card).length).toBe(4);
+    expect(wrapper.find(Card).length).toBe(5);
     const tasksCard = wrapper.find(Card).at(0);
-    const formsCard = wrapper.find(Card).at(1);
-    const casesCard = wrapper.find(Card).at(2);
-    const reportsCard = wrapper.find(Card).at(3);
+    const groupTasksCard = wrapper.find(Card).at(1);
+    const formsCard = wrapper.find(Card).at(2);
+    const casesCard = wrapper.find(Card).at(3);
+    const reportsCard = wrapper.find(Card).at(4);
 
-    expect(formsCard.find('h2').text()).toBe('pages.home.card.forms.title');
     expect(tasksCard.find('h2').text()).toBe('10');
-    expect(reportsCard.find('h2').text()).toBe('pages.home.card.reports.title');
+    expect(tasksCard.find('span').text()).toBe('pages.home.card.tasks.title');
+    expect(groupTasksCard.find('h2').text()).toBe('10');
+    expect(groupTasksCard.find('span').text()).toBe('pages.home.card.group-tasks.title');
+    expect(formsCard.find('h2').text()).toBe('pages.home.card.forms.title');
     expect(casesCard.find('h2').text()).toBe('pages.home.card.cases.title');
+    expect(reportsCard.find('h2').text()).toBe('pages.home.card.reports.title');
   });
 
   it('handles errors and sets it to zero', async () => {
@@ -53,16 +57,18 @@ describe('Home', () => {
       await wrapper.update();
     });
 
-    expect(wrapper.find(Card).length).toBe(4);
+    expect(wrapper.find(Card).length).toBe(5);
     const tasksCard = wrapper.find(Card).at(0);
-    const formsCard = wrapper.find(Card).at(1);
-    const casesCard = wrapper.find(Card).at(2);
-    const reportsCard = wrapper.find(Card).at(3);
+    const groupTasksCard = wrapper.find(Card).at(1);
+    const formsCard = wrapper.find(Card).at(2);
+    const casesCard = wrapper.find(Card).at(3);
+    const reportsCard = wrapper.find(Card).at(4);
 
-    expect(formsCard.find('h2').text()).toBe('pages.home.card.forms.title');
     expect(tasksCard.find('h2').text()).toBe('0');
-    expect(reportsCard.find('h2').text()).toBe('pages.home.card.reports.title');
+    expect(groupTasksCard.find('h2').text()).toBe('0');
+    expect(formsCard.find('h2').text()).toBe('pages.home.card.forms.title');
     expect(casesCard.find('h2').text()).toBe('pages.home.card.cases.title');
+    expect(reportsCard.find('h2').text()).toBe('pages.home.card.reports.title');
   });
 
   it('can handle onClick', async () => {
@@ -77,22 +83,26 @@ describe('Home', () => {
       await wrapper.update();
     });
 
-    expect(wrapper.find(Card).length).toBe(4);
+    expect(wrapper.find(Card).length).toBe(5);
     const tasksCard = wrapper.find(Card).at(0);
-    const formsCard = wrapper.find(Card).at(1);
-    const casesCard = wrapper.find(Card).at(2);
-    const reportsCard = wrapper.find(Card).at(3);
+    const groupTasksCard = wrapper.find(Card).at(1);
+    const formsCard = wrapper.find(Card).at(2);
+    const casesCard = wrapper.find(Card).at(3);
+    const reportsCard = wrapper.find(Card).at(4);
+
+    tasksCard.props().handleClick();
+    expect(mockNavigate).toBeCalledWith('/tasks/yours');
+
+    groupTasksCard.props().handleClick();
+    expect(mockNavigate).toBeCalledWith('/tasks');
 
     formsCard.props().handleClick();
     expect(mockNavigate).toBeCalledWith('/forms');
 
-    tasksCard.props().handleClick();
-    expect(mockNavigate).toBeCalledWith('/tasks');
+    casesCard.props().handleClick();
+    expect(mockNavigate).toBeCalledWith('/cases');
 
     reportsCard.props().handleClick();
     expect(mockNavigate).toBeCalledWith('/reports');
-
-    casesCard.props().handleClick();
-    expect(mockNavigate).toBeCalledWith('/cases');
   });
 });

--- a/client/src/pages/home/index.test.jsx
+++ b/client/src/pages/home/index.test.jsx
@@ -91,7 +91,7 @@ describe('Home', () => {
     const reportsCard = wrapper.find(Card).at(4);
 
     tasksCard.props().handleClick();
-    expect(mockNavigate).toBeCalledWith('/tasks/yours');
+    expect(mockNavigate).toBeCalledWith('/tasks/your-tasks');
 
     groupTasksCard.props().handleClick();
     expect(mockNavigate).toBeCalledWith('/tasks');

--- a/client/src/pages/tasks/routes.js
+++ b/client/src/pages/tasks/routes.js
@@ -13,7 +13,7 @@ const routes = mount({
       })
     )
   ),
-  '/yours': map((request, context) =>
+  '/your-tasks': map((request, context) =>
     withAuthentication(
       route({
         title: context.t('pages.tasks.yours.title'),

--- a/client/src/pages/tasks/routes.js
+++ b/client/src/pages/tasks/routes.js
@@ -8,6 +8,14 @@ const routes = mount({
   '/': map((request, context) =>
     withAuthentication(
       route({
+        title: context.t('pages.tasks.groups.title'),
+        view: <TasksListPage />,
+      })
+    )
+  ),
+  '/yours': map((request, context) =>
+    withAuthentication(
+      route({
         title: context.t('pages.tasks.yours.title'),
         view: <TasksListPage />,
       })


### PR DESCRIPTION
**AC**

Add the group task panel, design and text as per cop v1

**Notes**
- Content was added to translate.json in previous PR
- Page titles have not been updated for these pages, that will be done later

**Updated**
- added panel
- added /tasks/yours as the url for your tasks
- updated dashboard links & tests

**To test**
- view dashboard (/)
> you should see a panel for your tasks
> you should see a panel for group tasks
- click on your tasks
> you should be taken to /tasks/yours
- go back to dashboard
- click on group tasks
> you should be taken to /tasks