### PR TITLE
COP-3765 Add task filter bar to task list

### DIFF
--- a/client/.eslintrc.json
+++ b/client/.eslintrc.json
@@ -44,6 +44,16 @@
     "import/no-extraneous-dependencies": ["error", { "devDependencies": true }],
     "import/prefer-default-export": "off",
     "react/jsx-filename-extension": [1, { "extensions": [".js", ".jsx"] }],
-    "react/jsx-props-no-spreading": ["error", { "custom": "ignore" }]
+    "react/jsx-props-no-spreading": ["error", { "custom": "ignore" }],
+    "jsx-a11y/label-has-associated-control": [
+      "error",
+      {
+        "labelComponents": [],
+        "labelAttributes": [],
+        "controlComponents": [],
+        "assert": "either",
+        "depth": 25
+      }
+    ]
   }
 }

--- a/client/src/pages/tasks/TasksListPage.jsx
+++ b/client/src/pages/tasks/TasksListPage.jsx
@@ -3,24 +3,35 @@ import { useTranslation } from 'react-i18next';
 import { useKeycloak } from '@react-keycloak/web';
 import axios from 'axios';
 import _ from 'lodash';
+import PropTypes from 'prop-types';
 import ApplicationSpinner from '../../components/ApplicationSpinner';
 import { useIsMounted, useAxios } from '../../utils/hooks';
 import TaskList from './components/TaskList';
+import TaskFilters from './components/TaskFilters';
 
-const TasksListPage = () => {
+const TasksListPage = ({ taskType }) => {
   const { t } = useTranslation();
   const [keycloak] = useKeycloak();
+  const [filters, setFilters] = useState({
+    sortBy: '',
+    groupBy: '',
+    search: '',
+  });
   const [data, setData] = useState({
     isLoading: true,
     tasks: [],
-    total: 0,
     page: 0,
+    total: 0,
     maxResults: 20,
-    search: '',
   });
   const isMounted = useIsMounted();
   const axiosInstance = useAxios();
   const dataRef = useRef(data.tasks);
+
+  const handleFilters = (e) => {
+    setFilters({ ...filters, [e.target.name]: e.target.value });
+  };
+
   useEffect(() => {
     const source = axios.CancelToken.source();
     const loadTasks = async () => {
@@ -95,7 +106,6 @@ const TasksListPage = () => {
               total: taskCountResponse.data.count,
               page: data.page,
               maxResults: data.maxResults,
-              search: data.search,
             });
           }
         } catch (e) {
@@ -105,7 +115,6 @@ const TasksListPage = () => {
             total: 0,
             page: data.page,
             maxResults: data.maxResults,
-            search: '',
           });
         }
       }
@@ -122,7 +131,7 @@ const TasksListPage = () => {
     keycloak.tokenParsed.email,
     keycloak.tokenParsed.groups,
     isMounted,
-    data.search,
+    filters,
   ]);
 
   if (data.isLoading) {
@@ -132,11 +141,14 @@ const TasksListPage = () => {
     <>
       <div className="govuk-grid-row">
         <div className="govuk-grid-column-two-thirds">
-          <span className="govuk-caption-l">{t('pages.tasks.yours.caption')}</span>
+          <span className="govuk-caption-l">{t(`pages.tasks.${taskType}.caption`)}</span>
           <h1 className="govuk-heading-l">
-            {t('pages.tasks.yours.heading', { count: data.total })}
+            {t(`pages.tasks.${taskType}.heading`, { count: data.total })}
           </h1>
         </div>
+      </div>
+      <div>
+        <TaskFilters search={filters.search} handleFilters={handleFilters} />
       </div>
       <div className="govuk-grid-row">
         <div className="govuk-grid-column-full">
@@ -168,6 +180,10 @@ const TasksListPage = () => {
       </div>
     </>
   );
+};
+
+TasksListPage.propTypes = {
+  taskType: PropTypes.string.isRequired,
 };
 
 export default TasksListPage;

--- a/client/src/pages/tasks/components/TaskFilters.jsx
+++ b/client/src/pages/tasks/components/TaskFilters.jsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const TaskFilters = ({ search, handleFilters }) => {
+  return (
+    <div className="govuk-grid-row">
+      <div className="govuk-grid-column-one-third">
+        <div className="govuk-form-group">
+          <label className="govuk-label" htmlFor="sort">
+            Sort by
+            <select className="govuk-select" id="sort" name="sort" onChange={handleFilters}>
+              <option value="oldest-due-date">Oldest due date</option>
+              <option value="latest-due-date">Latest due date</option>
+              <option value="oldest-created-date">Oldest created date</option>
+              <option value="latest-created-date">Latest created date</option>
+              <option value="highest-priority">Highest priority</option>
+              <option value="lowest-priority">Lowest priority</option>
+            </select>
+          </label>
+        </div>
+      </div>
+      <div className="govuk-grid-column-one-third">
+        <div className="govuk-form-group">
+          <label className="govuk-label" htmlFor="group">
+            Group by
+            <select className="govuk-select" id="group" name="groupBy" onChange={handleFilters}>
+              <option value="category">Category</option>
+              <option value="bf-reference">BF Reference</option>
+              <option value="priority">Priority</option>
+              <option value="assignee">Assignee</option>
+            </select>
+          </label>
+        </div>
+      </div>
+      <div className="govuk-grid-column-one-third">
+        <div className="govuk-form-group">
+          <label className="govuk-label" htmlFor="filterTaskName">
+            Search by task name:
+            <input
+              className="govuk-input govuk-!-width-full"
+              id="filterTaskName"
+              type="text"
+              name="search"
+              value={search}
+              onChange={handleFilters}
+            />
+          </label>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+TaskFilters.defaultProps = {
+  search: '',
+};
+
+TaskFilters.propTypes = {
+  handleFilters: PropTypes.func.isRequired,
+  search: PropTypes.string,
+};
+
+export default TaskFilters;

--- a/client/src/pages/tasks/components/TaskFilters.jsx
+++ b/client/src/pages/tasks/components/TaskFilters.jsx
@@ -7,44 +7,44 @@ const TaskFilters = ({ search, handleFilters }) => {
       <div className="govuk-grid-column-one-third">
         <div className="govuk-form-group">
           <label className="govuk-label" htmlFor="sort">
-            Sort by
-            <select className="govuk-select" id="sort" name="sort" onChange={handleFilters}>
-              <option value="oldest-due-date">Oldest due date</option>
-              <option value="latest-due-date">Latest due date</option>
-              <option value="oldest-created-date">Oldest created date</option>
-              <option value="latest-created-date">Latest created date</option>
-              <option value="highest-priority">Highest priority</option>
-              <option value="lowest-priority">Lowest priority</option>
-            </select>
+            Sort by:
           </label>
+          <select className="govuk-select" id="sort" name="sort" onChange={handleFilters}>
+            <option value="oldest-due-date">Oldest due date</option>
+            <option value="latest-due-date">Latest due date</option>
+            <option value="oldest-created-date">Oldest created date</option>
+            <option value="latest-created-date">Latest created date</option>
+            <option value="highest-priority">Highest priority</option>
+            <option value="lowest-priority">Lowest priority</option>
+          </select>
         </div>
       </div>
       <div className="govuk-grid-column-one-third">
         <div className="govuk-form-group">
           <label className="govuk-label" htmlFor="group">
-            Group by
-            <select className="govuk-select" id="group" name="groupBy" onChange={handleFilters}>
-              <option value="category">Category</option>
-              <option value="bf-reference">BF Reference</option>
-              <option value="priority">Priority</option>
-              <option value="assignee">Assignee</option>
-            </select>
+            Group by:
           </label>
+          <select className="govuk-select" id="group" name="groupBy" onChange={handleFilters}>
+            <option value="category">Category</option>
+            <option value="bf-reference">BF Reference</option>
+            <option value="priority">Priority</option>
+            <option value="assignee">Assignee</option>
+          </select>
         </div>
       </div>
       <div className="govuk-grid-column-one-third">
         <div className="govuk-form-group">
           <label className="govuk-label" htmlFor="filterTaskName">
             Search by task name:
-            <input
-              className="govuk-input govuk-!-width-full"
-              id="filterTaskName"
-              type="text"
-              name="search"
-              value={search}
-              onChange={handleFilters}
-            />
           </label>
+          <input
+            className="govuk-input govuk-!-width-full"
+            id="filterTaskName"
+            type="text"
+            name="search"
+            value={search}
+            onChange={handleFilters}
+          />
         </div>
       </div>
     </div>

--- a/client/src/pages/tasks/components/TaskFilters.test.jsx
+++ b/client/src/pages/tasks/components/TaskFilters.test.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import TaskFilters from './TaskFilters';
+
+describe('TaskFilters', () => {
+  const mockHandleFilter = jest.fn();
+  it('renders without crashing', () => {
+    shallow(<TaskFilters search="test" handleFilters={mockHandleFilter} />);
+  });
+});

--- a/client/src/pages/tasks/routes.js
+++ b/client/src/pages/tasks/routes.js
@@ -9,7 +9,7 @@ const routes = mount({
     withAuthentication(
       route({
         title: context.t('pages.tasks.groups.title'),
-        view: <TasksListPage />,
+        view: <TasksListPage taskType="groups" />,
       })
     )
   ),
@@ -17,7 +17,7 @@ const routes = mount({
     withAuthentication(
       route({
         title: context.t('pages.tasks.yours.title'),
-        view: <TasksListPage />,
+        view: <TasksListPage taskType="yours" />,
       })
     )
   ),


### PR DESCRIPTION
### AC
Add filter bar to task list

### Updated
- Added a prop to pass down to `your-tasks` and `tasks` routes in `task/routes.js`, it passes a string down to the route to distinguish between task list content
- Created `TaskFilter` component for the task list page

### Notes
- The filter bar is not functional currently, it will be implemented fully later
- Need to change rendered tasks design in a later PR

### To test
- Pull and run cop-ui locally
- Login
- Navigate to `/tasks`:
  - You should see the dropdown selectors without error
  - Select different options on the dropdowns
  - You should not see any changes to the tasks displayed on screen
- Navigate to `/tasks/your-tasks`:
  - You should see the dropdown selectors without error
  - Select different options on the dropdowns
  - You should not see any changes to the tasks displayed on screen