### PR TITLE
COP-3765 task list design

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -4729,6 +4729,11 @@
         }
       }
     },
+    "dayjs": {
+      "version": "1.9.6",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.9.6.tgz",
+      "integrity": "sha512-HngNLtPEBWRo8EFVmHFmSXAjtCX8rGNqeXQI0Gh7wCTSqwaKgPIDqu9m07wABVopNwzvOeCb+2711vQhDlcIXw=="
+    },
     "debug": {
       "version": "3.1.0",
       "resolved": "http://localhost:4873/debug/-/debug-3.1.0.tgz",

--- a/client/package.json
+++ b/client/package.json
@@ -8,6 +8,7 @@
     "@react-keycloak/web": "^2.1.1",
     "@testing-library/jest-dom": "^4.2.4",
     "axios": "^0.19.2",
+    "dayjs": "^1.9.6",
     "govuk-colours": "^1.1.0",
     "govuk-frontend": "^3.6.0",
     "html-react-parser": "^0.10.5",

--- a/client/src/pages/tasks/components/TaskList.jsx
+++ b/client/src/pages/tasks/components/TaskList.jsx
@@ -1,50 +1,39 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import './TaskList.scss';
-import { useNavigation } from 'react-navi';
-import { useTranslation } from 'react-i18next';
 import _ from 'lodash';
+import TaskListItem from './TaskListItem';
 
 const TaskList = ({ tasks }) => {
-  const navigation = useNavigation();
-  const { t } = useTranslation();
-
   const groupedByCategory = _.groupBy(tasks, (x) => x.category);
-
   return (
     <div>
-      <ol className="app-task-list">
-        {Object.keys(groupedByCategory).map((key, index) => (
-          <div key={key}>
-            <li>
-              <h2 className="app-task-list__section">
-                <span className="app-task-list__section-number">{index + 1}.</span> {key}
-              </h2>
-              <ul className="app-task-list__items">
+      <ul className="app-task-list">
+        {Object.keys(groupedByCategory).map((key) => {
+          return (
+            <div key={key} className="govuk-grid-row">
+              <div className="govuk-grid-column-full">
+                <hr
+                  style={{
+                    borderBottom: '3px solid #1d70b8',
+                    borderTop: 'none',
+                  }}
+                />
+                <h2 className="app-task-list__section">{key}</h2>
                 {groupedByCategory[key].map((task) => (
-                  <li key={task.id} className="app-task-list__item">
-                    <span className="app-task-list__task-name">
-                      <a
-                        href={`/task/${task.id}`}
-                        onClick={async (e) => {
-                          e.preventDefault();
-                          await navigation.navigate(`/tasks/${task.id}`);
-                        }}
-                        aria-describedby={task.name}
-                      >
-                        {task.name}
-                      </a>
-                    </span>
-                    <strong className="govuk-tag app-task-list__task-open">
-                      {t('pages.tasks.list.status')}
-                    </strong>
-                  </li>
+                  <TaskListItem
+                    key={task.id}
+                    id={task.id}
+                    due={task.due}
+                    name={task.name}
+                    assignee={task.assignee}
+                  />
                 ))}
-              </ul>
-            </li>
-          </div>
-        ))}
-      </ol>
+              </div>
+            </div>
+          );
+        })}
+      </ul>
     </div>
   );
 };

--- a/client/src/pages/tasks/components/TaskList.jsx
+++ b/client/src/pages/tasks/components/TaskList.jsx
@@ -19,7 +19,7 @@ const TaskList = ({ tasks }) => {
                     borderTop: 'none',
                   }}
                 />
-                <h2 className="app-task-list__section">{key}</h2>
+                <h2 className="app-task-list__section">{`${groupedByCategory[key].length} ${key} tasks`}</h2>
                 {groupedByCategory[key].map((task) => (
                   <TaskListItem
                     key={task.id}

--- a/client/src/pages/tasks/components/TaskList.test.jsx
+++ b/client/src/pages/tasks/components/TaskList.test.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { shallow, mount } from 'enzyme';
+import { Link } from 'react-navi';
 import TaskList from './TaskList';
-import { mockNavigate } from '../../../setupTests';
 
 describe('TaskList', () => {
   it('renders without crashing', () => {
@@ -9,21 +9,18 @@ describe('TaskList', () => {
   });
 
   it('can click on a task', () => {
-    const wrapper = shallow(
+    const wrapper = mount(
       <TaskList
         tasks={[
           {
-            id: 'id',
-            name: 'name',
+            id: '1',
+            name: 'test',
+            due: '19/03/2020',
           },
         ]}
       />
     );
 
-    wrapper.find('a').simulate('click', {
-      preventDefault: () => {},
-    });
-
-    expect(mockNavigate).toBeCalledWith('/tasks/id');
+    expect(wrapper.find(Link).at(0).props().href).toBe('/tasks/1');
   });
 });

--- a/client/src/pages/tasks/components/TaskListItem.jsx
+++ b/client/src/pages/tasks/components/TaskListItem.jsx
@@ -1,0 +1,119 @@
+import React from 'react';
+import { Link } from 'react-navi';
+import PropTypes from 'prop-types';
+import dayjs from 'dayjs';
+import relativeTime from 'dayjs/plugin/relativeTime';
+import './TaskListItem.scss';
+import { useKeycloak } from '@react-keycloak/web';
+
+dayjs.extend(relativeTime);
+
+const TaskListItem = ({ id, due, name, assignee }) => {
+  const [keycloak] = useKeycloak();
+  const currentUser = keycloak.tokenParsed.email;
+
+  const isOverDue = () => {
+    if (dayjs(due).fromNow().includes('ago')) {
+      return (
+        <span
+          aria-label={`due ${dayjs(due).fromNow()}`}
+          className="govuk-!-font-size-19 govuk-!-font-weight-bold overdue"
+        >
+          {`Overdue ${dayjs(due).fromNow()}`}
+        </span>
+      );
+    } 
+      return (
+        <span
+          aria-label={`due ${dayjs(due).fromNow()}`}
+          className="govuk-!-font-size-19 govuk-!-font-weight-bold not-overdue"
+        >
+          {`Due ${dayjs(due).fromNow()}`}
+        </span>
+      );
+    
+  };
+
+  const isAssigned = () => {
+    if (!assignee) {
+      return 'Unassigned';
+    } if (assignee === currentUser) {
+      return 'Assigned to you';
+    } 
+      return assignee;
+    
+  };
+
+  const handleClaim = (taskId) => {
+    return taskId;
+  };
+
+  const handleUnclaim = (taskId) => {
+    return taskId;
+  };
+
+  const canClaimTask = () => {
+    if (assignee === null || assignee !== currentUser) {
+      return (
+        <button
+          type="submit"
+          id="actionButton"
+          className="govuk-button"
+          onClick={() => handleClaim(id)}
+        >
+          Claim
+        </button>
+      );
+    } 
+      return (
+        <button
+          type="submit"
+          id="actionButton"
+          className="govuk-button"
+          onClick={() => handleUnclaim(id)}
+        >
+          Unclaim
+        </button>
+      );
+    
+  };
+
+  return (
+    <div className="govuk-grid-row govuk-!-margin-bottom-3">
+      <div className="govuk-grid-column-one-half govuk-!-margin-bottom-3">
+        <span className="govuk-caption-m">{id}</span>
+        <span className="govuk-!-font-size-19 govuk-!-font-weight-bold">
+          <Link
+            className="govuk-link govuk-!-font-size-19"
+            href={`/tasks/${id}`}
+            aria-describedby={name}
+          >
+            {name}
+          </Link>
+        </span>
+      </div>
+      <div className="govuk-grid-column-one-half">
+        <div className="govuk-grid-row">
+          <div className="govuk-grid-column-one-third govuk-!-margin-bottom-3">{isOverDue()}</div>
+          <div className="govuk-grid-column-one-third govuk-!-margin-bottom-3">
+            <span className="govuk-!-font-size-19 govuk-!-font-weight-bold">{isAssigned()}</span>
+          </div>
+          <div className="govuk-grid-column-one-third claim-task">{canClaimTask()}</div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+TaskListItem.defaultProps = {
+  assignee: null,
+};
+
+TaskListItem.propTypes = {
+  id: PropTypes.string.isRequired,
+  due: PropTypes.string.isRequired,
+  name: PropTypes.string.isRequired,
+  assignee: PropTypes.string,
+};
+
+export default TaskListItem;

--- a/client/src/pages/tasks/components/TaskListItem.scss
+++ b/client/src/pages/tasks/components/TaskListItem.scss
@@ -1,3 +1,5 @@
+$govuk-page-width: 1400px;
+
 @import '~govuk-frontend/govuk/all';
 
 .overdue {

--- a/client/src/pages/tasks/components/TaskListItem.scss
+++ b/client/src/pages/tasks/components/TaskListItem.scss
@@ -1,0 +1,13 @@
+@import '~govuk-frontend/govuk/all';
+
+.overdue {
+  color: govuk-colour("red");
+}
+
+.not-overdue {
+  color: govuk-colour("green");
+}
+
+.claim-task {
+  text-align: right;
+}

--- a/client/src/pages/tasks/components/TaskListItem.test.jsx
+++ b/client/src/pages/tasks/components/TaskListItem.test.jsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { mount, shallow } from 'enzyme';
+import { Link } from 'react-navi';
+import dayjs from 'dayjs';
+import relativeTime from 'dayjs/plugin/relativeTime';
+import TaskListItem from './TaskListItem';
+
+dayjs.extend(relativeTime);
+
+describe('TaskListItem', () => {
+  it('can render without error', () => {
+    shallow(<TaskListItem id="1" due="19/03/2020" name="test" assignee="test" />);
+  });
+
+  it('can click on a task', () => {
+    const wrapper = mount(
+      <TaskListItem id="1" due="19/03/2020" name="test" assignee="test" />
+    );
+
+    expect(wrapper.find(Link).at(0).props().href).toBe('/tasks/1');
+  });
+
+  it('can render "Overdue" if task due date is in the past', () => {
+    const wrapper = mount(
+      <TaskListItem id="1" due="2020/03/19" name="test" assignee="test" />
+    );
+
+    const taskDue = wrapper
+      .find('div[className="govuk-grid-column-one-third govuk-!-margin-bottom-3"]')
+      .at(0);
+
+    expect(taskDue.text()).toMatch(/Overdue/);
+  });
+
+  it('can render "Due" if task due date is in the future', () => {
+    const tomorrow = dayjs().add(1, 'day').format();
+    const wrapper = mount(<TaskListItem id="1" due={tomorrow} name="test" assignee="test" />);
+
+    const taskDue = wrapper
+      .find('div[className="govuk-grid-column-one-third govuk-!-margin-bottom-3"]')
+      .at(0);
+
+    expect(taskDue.text()).toMatch(/Due in a day/);
+  });
+});


### PR DESCRIPTION
### AC
The tasks list page design should be the same as COPv1 UI task list page

### Updated
- Added dayjs package, this is due to momentjs not being maintained anymore and has recommended a switch to a new package (dayjs being a suggestion)
- Refactored TaskList.jsx removing large chunks of jsx and moved them out to separate files (TaskListItem.jsx)
- Added TaskListItem.jsx to handle rendering each individual task
- Added initial tests for TaskListItem.jsx

### Notes
- The functionality is still limited (can't claim task, different grouping, sorting, search etc) as this ticket is for setting up the design, further functionality will be added in later PRs
- Business key is not returned from tasks api call and so the task id is being used as a placeholder for now

### To test
- Pull and run cop locally
- Login
- Navigate to /tasks
- You should see a list of tasks that looks like COPv1 UI
- You should be able to click on a task and it should take you to a single task page