### PR TITLE
COP-2808 Sort tasks by due date/created date/priority

### DIFF
--- a/client/src/pages/tasks/TasksListPage.jsx
+++ b/client/src/pages/tasks/TasksListPage.jsx
@@ -13,8 +13,8 @@ const TasksListPage = ({ taskType }) => {
   const { t } = useTranslation();
   const [keycloak] = useKeycloak();
   const [filters, setFilters] = useState({
-    sortBy: '',
-    groupBy: '',
+    sortBy: 'asc-dueDate',
+    groupBy: 'category',
     search: '',
   });
   const [data, setData] = useState({

--- a/client/src/pages/tasks/TasksListPage.jsx
+++ b/client/src/pages/tasks/TasksListPage.jsx
@@ -27,11 +27,9 @@ const TasksListPage = ({ taskType }) => {
   const isMounted = useIsMounted();
   const axiosInstance = useAxios();
   const dataRef = useRef(data.tasks);
-
   const handleFilters = (e) => {
     setFilters({ ...filters, [e.target.name]: e.target.value });
   };
-
   const formatSortByValue = (sortValue) => {
     const [sortOrder, sortVariable] = sortValue.split('-');
     return { sortOrder, sortVariable };
@@ -55,9 +53,7 @@ const TasksListPage = ({ taskType }) => {
               ],
             },
           });
-
           const { sortOrder, sortVariable } = formatSortByValue(filters.sortBy);
-
           const tasksResponse = await axiosInstance({
             method: 'POST',
             url: '/camunda/engine-rest/task',
@@ -81,11 +77,9 @@ const TasksListPage = ({ taskType }) => {
               ],
             },
           });
-
           const processDefinitionIds = _.uniq(
             tasksResponse.data.map((task) => task.processDefinitionId)
           );
-
           const definitionResponse = await axiosInstance({
             method: 'GET',
             url: '/camunda/engine-rest/process-definition',

--- a/client/src/pages/tasks/components/TaskFilters.jsx
+++ b/client/src/pages/tasks/components/TaskFilters.jsx
@@ -9,13 +9,13 @@ const TaskFilters = ({ search, handleFilters }) => {
           <label className="govuk-label" htmlFor="sort">
             Sort by:
           </label>
-          <select className="govuk-select" id="sort" name="sort" onChange={handleFilters}>
-            <option value="oldest-due-date">Oldest due date</option>
-            <option value="latest-due-date">Latest due date</option>
-            <option value="oldest-created-date">Oldest created date</option>
-            <option value="latest-created-date">Latest created date</option>
-            <option value="highest-priority">Highest priority</option>
-            <option value="lowest-priority">Lowest priority</option>
+          <select className="govuk-select" id="sort" name="sortBy" onChange={handleFilters}>
+            <option value="asc-dueDate">Oldest due date</option>
+            <option value="desc-dueDate">Latest due date</option>
+            <option value="asc-created">Oldest created date</option>
+            <option value="desc-created">Latest created date</option>
+            <option value="asc-priority">Highest priority</option>
+            <option value="desc-priority">Lowest priority</option>
           </select>
         </div>
       </div>

--- a/client/src/pages/tasks/components/TaskFilters.test.jsx
+++ b/client/src/pages/tasks/components/TaskFilters.test.jsx
@@ -4,7 +4,42 @@ import TaskFilters from './TaskFilters';
 
 describe('TaskFilters', () => {
   const mockHandleFilter = jest.fn();
+
+  beforeEach(() => {
+    mockHandleFilter.mockClear();
+  });
+
   it('renders without crashing', () => {
-    shallow(<TaskFilters search="test" handleFilters={mockHandleFilter} />);
+    shallow(<TaskFilters search="" handleFilters={mockHandleFilter} />);
+  });
+
+  it('calls handleFilter when sortBy option has been chosen', () => {
+    const wrapper = shallow(<TaskFilters search="" handleFilters={mockHandleFilter} />);
+
+    const sortBy = wrapper.find('select[id="sort"]').at(0);
+
+    sortBy.simulate('change', { event: { target: { value: 'desc-dueDate' } } });
+
+    expect(mockHandleFilter).toHaveBeenCalled();
+  });
+
+  it('calls handleFilter when groupBy option has been chosen', () => {
+    const wrapper = shallow(<TaskFilters search="" handleFilters={mockHandleFilter} />);
+
+    const groupBy = wrapper.find('select[id="group"]').at(0);
+
+    groupBy.simulate('change', { event: { target: { value: 'priority' } } });
+
+    expect(mockHandleFilter).toHaveBeenCalled();
+  });
+
+  it('calls handleFilter when search bar has input', () => {
+    const wrapper = shallow(<TaskFilters search="" handleFilters={mockHandleFilter} />);
+
+    const searchBar = wrapper.find('input[id="filterTaskName"]').at(0);
+
+    searchBar.simulate('change', { event: { target: { value: 'Border' } } });
+
+    expect(mockHandleFilter).toHaveBeenCalled();
   });
 });

--- a/client/src/pages/tasks/components/TaskFilters.test.jsx
+++ b/client/src/pages/tasks/components/TaskFilters.test.jsx
@@ -15,7 +15,6 @@ describe('TaskFilters', () => {
 
   it('calls handleFilter when sortBy option has been chosen', () => {
     const wrapper = shallow(<TaskFilters search="" handleFilters={mockHandleFilter} />);
-
     const sortBy = wrapper.find('select[id="sort"]').at(0);
 
     sortBy.simulate('change', { event: { target: { value: 'desc-dueDate' } } });
@@ -25,7 +24,6 @@ describe('TaskFilters', () => {
 
   it('calls handleFilter when groupBy option has been chosen', () => {
     const wrapper = shallow(<TaskFilters search="" handleFilters={mockHandleFilter} />);
-
     const groupBy = wrapper.find('select[id="group"]').at(0);
 
     groupBy.simulate('change', { event: { target: { value: 'priority' } } });
@@ -35,7 +33,6 @@ describe('TaskFilters', () => {
 
   it('calls handleFilter when search bar has input', () => {
     const wrapper = shallow(<TaskFilters search="" handleFilters={mockHandleFilter} />);
-
     const searchBar = wrapper.find('input[id="filterTaskName"]').at(0);
 
     searchBar.simulate('change', { event: { target: { value: 'Border' } } });

--- a/client/src/pages/tasks/components/TaskListItem.jsx
+++ b/client/src/pages/tasks/components/TaskListItem.jsx
@@ -11,7 +11,6 @@ dayjs.extend(relativeTime);
 const TaskListItem = ({ id, due, name, assignee }) => {
   const [keycloak] = useKeycloak();
   const currentUser = keycloak.tokenParsed.email;
-
   const isOverDue = () => {
     if (dayjs(due).fromNow().includes('ago')) {
       return (
@@ -22,36 +21,31 @@ const TaskListItem = ({ id, due, name, assignee }) => {
           {`Overdue ${dayjs(due).fromNow()}`}
         </span>
       );
-    } 
-      return (
-        <span
-          aria-label={`due ${dayjs(due).fromNow()}`}
-          className="govuk-!-font-size-19 govuk-!-font-weight-bold not-overdue"
-        >
-          {`Due ${dayjs(due).fromNow()}`}
-        </span>
-      );
-    
+    }
+    return (
+      <span
+        aria-label={`due ${dayjs(due).fromNow()}`}
+        className="govuk-!-font-size-19 govuk-!-font-weight-bold not-overdue"
+      >
+        {`Due ${dayjs(due).fromNow()}`}
+      </span>
+    );
   };
-
   const isAssigned = () => {
     if (!assignee) {
       return 'Unassigned';
-    } if (assignee === currentUser) {
+    }
+    if (assignee === currentUser) {
       return 'Assigned to you';
-    } 
-      return assignee;
-    
+    }
+    return assignee;
   };
-
   const handleClaim = (taskId) => {
     return taskId;
   };
-
   const handleUnclaim = (taskId) => {
     return taskId;
   };
-
   const canClaimTask = () => {
     if (assignee === null || assignee !== currentUser) {
       return (
@@ -64,18 +58,17 @@ const TaskListItem = ({ id, due, name, assignee }) => {
           Claim
         </button>
       );
-    } 
-      return (
-        <button
-          type="submit"
-          id="actionButton"
-          className="govuk-button"
-          onClick={() => handleUnclaim(id)}
-        >
-          Unclaim
-        </button>
-      );
-    
+    }
+    return (
+      <button
+        type="submit"
+        id="actionButton"
+        className="govuk-button"
+        onClick={() => handleUnclaim(id)}
+      >
+        Unclaim
+      </button>
+    );
   };
 
   return (


### PR DESCRIPTION
### AC
User is able to sort tasks by due date, created date, and priority

### Updated
- Set the default values for sorting and grouping to be the same as COPv1 UI
- Added `sorting` to json body request to cop-service
- Only trigger api call to cop-service when sorting and search have been used, not grouping
- Changed `TaskFilters.jsx` option values to match the format in the camunda API docs
- Added more tests to `TaskFilters.jsx` 

### Notes
- Group by and search functionality have not been added yet

### To test
- Pull and run cop-ui locally (spin up docker containers etc.)
- Login
- If you have already submitted forms and have tasks then skip the next step
- Submit at least 2 forms (record border event can be submitted pending form changes, this may require making officer details not mandatory in order to complete the form and submit successfully).
- Navigate to `/tasks`
- The tasks should be sorted by oldest due date by default
- Select `Latest due date` from the sort by dropdown
- The tasks should be sorted by latest due date
