### PR TITLE
COP-2809 Group tasks visually by category/BF ref/priority/assignee

### DIFF
--- a/client/src/pages/tasks/TasksListPage.jsx
+++ b/client/src/pages/tasks/TasksListPage.jsx
@@ -182,7 +182,7 @@ const TasksListPage = ({ taskType }) => {
       </div>
       <div className="govuk-grid-row">
         <div className="govuk-grid-column-full">
-          <TaskList tasks={data.tasks} />
+          <TaskList tasks={data.tasks} groupBy={filters.groupBy} />
           {data.total > data.maxResults && data.tasks.length < data.total ? (
             <ul className="govuk-list">
               <li>

--- a/client/src/pages/tasks/TasksListPage.jsx
+++ b/client/src/pages/tasks/TasksListPage.jsx
@@ -77,6 +77,7 @@ const TasksListPage = ({ taskType }) => {
               ],
             },
           });
+          // This generates a unique list of process definition ids to use for a call to camunda for task categories
           const processDefinitionIds = _.uniq(
             tasksResponse.data.map((task) => task.processDefinitionId)
           );
@@ -85,6 +86,17 @@ const TasksListPage = ({ taskType }) => {
             url: '/camunda/engine-rest/process-definition',
             params: {
               processDefinitionIdIn: processDefinitionIds.toString(),
+            },
+          });
+          // This generates a unique list of process instance ids to use for a call to camunda for task business keys
+          const processInstanceIds = _.uniq(
+            tasksResponse.data.map((task) => task.processInstanceId)
+          );
+          const processInstanceResponse = await axiosInstance({
+            method: 'POST',
+            url: '/camunda/engine-rest/process-instance',
+            data: {
+              processInstanceIds,
             },
           });
 
@@ -99,9 +111,18 @@ const TasksListPage = ({ taskType }) => {
                   definitionResponse.data,
                   (definition) => definition.id === task.processDefinitionId
                 );
+                const processInstance = _.find(
+                  processInstanceResponse.data,
+                  (instance) => instance.id === task.processInstanceId
+                );
+
                 if (processDefinition) {
                   // eslint-disable-next-line no-param-reassign
                   task.category = processDefinition.category;
+                }
+                if (processInstance) {
+                  // eslint-disable-next-line no-param-reassign
+                  task.businessKey = processInstance.businessKey;
                 }
               });
             }

--- a/client/src/pages/tasks/TasksListPage.test.jsx
+++ b/client/src/pages/tasks/TasksListPage.test.jsx
@@ -2,13 +2,18 @@ import React from 'react';
 import { shallow, mount } from 'enzyme';
 import MockAdapter from 'axios-mock-adapter';
 import axios from 'axios';
-import { act } from '@testing-library/react';
+import { act, render, screen, waitFor, fireEvent, queryByAttribute } from '@testing-library/react';
+import dayjs from 'dayjs';
+import relativeTime from 'dayjs/plugin/relativeTime';
 import TasksListPage from './TasksListPage';
 import ApplicationSpinner from '../../components/ApplicationSpinner';
 import TaskList from './components/TaskList';
 
+dayjs.extend(relativeTime);
+
 describe('TasksListPage', () => {
   const mockAxios = new MockAdapter(axios);
+  const getById = queryByAttribute.bind(null, 'id');
   let mockData;
 
   beforeEach(() => {
@@ -18,8 +23,13 @@ describe('TasksListPage', () => {
     for (let i = 0; i < 10; i += 1) {
       mockData.push({
         id: `id${Math.random() + Math.random()}`,
-        name: `name${i}`,
+        name: 'test-name',
         processDefinitionId: 'processDefinitionId0',
+        processInstanceId: 'processInstanceId0',
+        due: dayjs().add(i, 'day').format(),
+        created: dayjs().subtract(i, 'day').format(),
+        assignee: 'john@doe.com',
+        priority: 100,
       });
     }
   });
@@ -71,7 +81,7 @@ describe('TasksListPage', () => {
     mockAxios.onPost('/camunda/engine-rest/process-instance').reply(200, [
       {
         businessKey: 'TEST-BUSINESS-KEY',
-        processInstanceId: 'processDefinitionId0',
+        id: 'processDefinitionId0',
       },
     ]);
     const wrapper = await mount(<TasksListPage />);
@@ -98,5 +108,90 @@ describe('TasksListPage', () => {
     // Following assertions look to see how many axios calls are made in the course of the test. In this instance, 2 GET requests and 6 POST requests are expected
     expect(mockAxios.history.get.length).toBe(2);
     expect(mockAxios.history.post.length).toBe(6);
+  });
+
+  it('can group tasks correctly', async () => {
+    // Add more objects with different processDefinitionIds to map different categories to them. Also added differing priorities to test priority grouping
+    mockData = mockData.concat([
+      {
+        id: 'enhance-category',
+        name: 'enhance-task',
+        processDefinitionId: 'processDefinitionId1',
+        processInstanceId: 'processInstanceId1',
+        due: dayjs().format(),
+        created: dayjs().format(),
+        assignee: 'john@doe.com',
+        priority: 50,
+      },
+      {
+        id: 'enhance-category1',
+        name: 'enhance-task',
+        processDefinitionId: 'processDefinitionId1',
+        processInstanceId: 'processInstanceId1',
+        due: dayjs().format(),
+        created: dayjs().format(),
+        assignee: 'john@doe.com',
+        priority: 150,
+      },
+    ]);
+    // Provides the category to process definition id mapping
+    mockAxios.onGet('/camunda/engine-rest/process-definition').reply(200, [
+      {
+        category: 'test',
+        id: 'processDefinitionId0',
+      },
+      {
+        category: 'enhance',
+        id: 'processDefinitionId1',
+      },
+    ]);
+    mockAxios.onPost('/camunda/engine-rest/task').reply(200, mockData);
+    mockAxios.onPost('/camunda/engine-rest/task/count').reply(200, {
+      count: 100,
+    });
+    // Provides the business key to process instance id mapping
+    mockAxios.onPost('/camunda/engine-rest/process-instance').reply(200, [
+      {
+        businessKey: 'TEST-BUSINESS-KEY0',
+        id: 'processInstanceId0',
+      },
+      {
+        businessKey: 'TEST-BUSINESS-KEY1',
+        id: 'processInstanceId1',
+      },
+    ]);
+    const { container } = render(<TasksListPage />);
+
+    await waitFor(() => {
+      // Check if the grouping title has the correct number of tasks associated with it for categories, the number shown is correspondant with the number of tasks pulled from the api call. Categories is the default grouping when component has mounted
+      expect(screen.getByText('10 test tasks')).toBeTruthy();
+      expect(screen.getByText('2 enhance tasks')).toBeTruthy();
+    });
+
+    // Grab groupByDropdown after initial assertions, cannot define this before the await as the component has not mounted at that point
+    const groupByDropDown = getById(container, 'group');
+
+    fireEvent.change(groupByDropDown, { target: { value: 'priority' } });
+
+    await waitFor(() => {
+      // Same as category assertions but with priority
+      expect(screen.getByText('1 Low task')).toBeTruthy();
+      expect(screen.getByText('10 Medium tasks')).toBeTruthy();
+      expect(screen.getByText('1 High task')).toBeTruthy();
+    });
+
+    fireEvent.change(groupByDropDown, { target: { value: 'assignee' } });
+
+    await waitFor(() => {
+      // Same as category assertions but with assignee, only one assertion here as all the tasks are assigned to john@doe.com
+      expect(screen.getByText('12 john@doe.com tasks')).toBeTruthy();
+    });
+
+    fireEvent.change(groupByDropDown, { target: { value: 'businessKey' } });
+
+    await waitFor(() => {
+      expect(screen.getByText('10 TEST-BUSINESS-KEY0 tasks')).toBeTruthy();
+      expect(screen.getByText('2 TEST-BUSINESS-KEY1 tasks')).toBeTruthy();
+    });
   });
 });

--- a/client/src/pages/tasks/TasksListPage.test.jsx
+++ b/client/src/pages/tasks/TasksListPage.test.jsx
@@ -9,10 +9,19 @@ import TaskList from './components/TaskList';
 
 describe('TasksListPage', () => {
   const mockAxios = new MockAdapter(axios);
+  let mockData;
 
   beforeEach(() => {
     jest.spyOn(console, 'error').mockImplementation(() => {});
     mockAxios.reset();
+    mockData = [];
+    for (let i = 0; i < 10; i += 1) {
+      mockData.push({
+        id: `id${Math.random() + Math.random()}`,
+        name: `name${i}`,
+        processDefinitionId: 'processDefinitionId0',
+      });
+    }
   });
 
   it('renders without crashing', () => {
@@ -47,14 +56,7 @@ describe('TasksListPage', () => {
   });
 
   it('can click on load more', async () => {
-    const mockData = [];
-    for (let i = 0; i < 10; i += 1) {
-      mockData.push({
-        id: `id${Math.random() + Math.random()}`,
-        name: `name${i}`,
-        processDefinitionId: 'processDefinitionId0',
-      });
-    }
+    // This call is required in order to map a category to each task in mockData
     mockAxios.onGet('/camunda/engine-rest/process-definition').reply(200, [
       {
         category: 'test',
@@ -65,6 +67,7 @@ describe('TasksListPage', () => {
     mockAxios.onPost('/camunda/engine-rest/task/count').reply(200, {
       count: 100,
     });
+    // This call is required in order to map a business key to each task in mockData
     mockAxios.onPost('/camunda/engine-rest/process-instance').reply(200, [
       {
         businessKey: 'TEST-BUSINESS-KEY',

--- a/client/src/pages/tasks/TasksListPage.test.jsx
+++ b/client/src/pages/tasks/TasksListPage.test.jsx
@@ -21,6 +21,7 @@ describe('TasksListPage', () => {
 
   it('renders application spinner when getting data', async () => {
     const wrapper = await mount(<TasksListPage />);
+
     expect(wrapper.find(ApplicationSpinner).exists()).toBe(true);
   });
 
@@ -31,11 +32,9 @@ describe('TasksListPage', () => {
         name: 'name',
       },
     ]);
-
     mockAxios.onPost('/camunda/engine-rest/task/count').reply(200, {
       count: 1,
     });
-
     const wrapper = await mount(<TasksListPage />);
 
     await act(async () => {
@@ -49,28 +48,29 @@ describe('TasksListPage', () => {
 
   it('can click on load more', async () => {
     const mockData = [];
-    // eslint-disable-next-line no-plusplus
-    for (let i = 0; i < 10; i++) {
+    for (let i = 0; i < 10; i += 1) {
       mockData.push({
         id: `id${Math.random() + Math.random()}`,
         name: `name${i}`,
         processDefinitionId: 'processDefinitionId0',
       });
     }
-
     mockAxios.onGet('/camunda/engine-rest/process-definition').reply(200, [
       {
         category: 'test',
         id: 'processDefinitionId0',
       },
     ]);
-
     mockAxios.onPost('/camunda/engine-rest/task').reply(200, mockData);
-
     mockAxios.onPost('/camunda/engine-rest/task/count').reply(200, {
       count: 100,
     });
-
+    mockAxios.onPost('/camunda/engine-rest/process-instance').reply(200, [
+      {
+        businessKey: 'TEST-BUSINESS-KEY',
+        processInstanceId: 'processDefinitionId0',
+      },
+    ]);
     const wrapper = await mount(<TasksListPage />);
 
     await act(async () => {
@@ -92,7 +92,8 @@ describe('TasksListPage', () => {
       await wrapper.update();
     });
 
+    // Following assertions look to see how many axios calls are made in the course of the test. In this instance, 2 GET requests and 6 POST requests are expected
     expect(mockAxios.history.get.length).toBe(2);
-    expect(mockAxios.history.post.length).toBe(4);
+    expect(mockAxios.history.post.length).toBe(6);
   });
 });

--- a/client/src/pages/tasks/components/TaskFilters.jsx
+++ b/client/src/pages/tasks/components/TaskFilters.jsx
@@ -26,7 +26,7 @@ const TaskFilters = ({ search, handleFilters }) => {
           </label>
           <select className="govuk-select" id="group" name="groupBy" onChange={handleFilters}>
             <option value="category">Category</option>
-            <option value="bf-reference">BF Reference</option>
+            <option value="businessKey">BF Reference</option>
             <option value="priority">Priority</option>
             <option value="assignee">Assignee</option>
           </select>

--- a/client/src/pages/tasks/components/TaskList.jsx
+++ b/client/src/pages/tasks/components/TaskList.jsx
@@ -6,7 +6,7 @@ import TaskListItem from './TaskListItem';
 import { formatPriority } from '../utils';
 
 const TaskList = ({ tasks, groupBy }) => {
-  const groupedByCategory = _.groupBy(tasks, (x) => x[groupBy]);
+  const tasksGroupedBy = _.groupBy(tasks, (x) => x[groupBy]);
   const isPriority = (keyName) => {
     if (groupBy === 'priority') {
       // Use parseInt as formatPriority takes a number as an argument
@@ -18,8 +18,8 @@ const TaskList = ({ tasks, groupBy }) => {
   return (
     <div>
       <ul className="app-task-list">
-        {Object.keys(groupedByCategory).map((key) => {
-          const numberOfTasks = groupedByCategory[key].length;
+        {Object.keys(tasksGroupedBy).map((key) => {
+          const numberOfTasks = tasksGroupedBy[key].length;
           return (
             <div key={key} className="govuk-grid-row">
               <div className="govuk-grid-column-full">
@@ -32,7 +32,7 @@ const TaskList = ({ tasks, groupBy }) => {
                 <h2 className="app-task-list__section">{`${numberOfTasks} ${isPriority(key)} ${
                   numberOfTasks < 2 ? 'task' : 'tasks'
                 }`}</h2>
-                {groupedByCategory[key].map((task) => (
+                {tasksGroupedBy[key].map((task) => (
                   <TaskListItem
                     key={task.id}
                     id={task.id}

--- a/client/src/pages/tasks/components/TaskList.jsx
+++ b/client/src/pages/tasks/components/TaskList.jsx
@@ -27,6 +27,7 @@ const TaskList = ({ tasks }) => {
                     due={task.due}
                     name={task.name}
                     assignee={task.assignee}
+                    businessKey={task.businessKey}
                   />
                 ))}
               </div>

--- a/client/src/pages/tasks/components/TaskList.jsx
+++ b/client/src/pages/tasks/components/TaskList.jsx
@@ -3,13 +3,23 @@ import PropTypes from 'prop-types';
 import './TaskList.scss';
 import _ from 'lodash';
 import TaskListItem from './TaskListItem';
+import { formatPriority } from '../utils';
 
-const TaskList = ({ tasks }) => {
-  const groupedByCategory = _.groupBy(tasks, (x) => x.category);
+const TaskList = ({ tasks, groupBy }) => {
+  const groupedByCategory = _.groupBy(tasks, (x) => x[groupBy]);
+  const isPriority = (keyName) => {
+    if (groupBy === 'priority') {
+      // Use parseInt as formatPriority takes a number as an argument
+      return formatPriority(parseInt(keyName, 10));
+    }
+    return keyName;
+  };
+
   return (
     <div>
       <ul className="app-task-list">
         {Object.keys(groupedByCategory).map((key) => {
+          const numberOfTasks = groupedByCategory[key].length;
           return (
             <div key={key} className="govuk-grid-row">
               <div className="govuk-grid-column-full">
@@ -19,7 +29,9 @@ const TaskList = ({ tasks }) => {
                     borderTop: 'none',
                   }}
                 />
-                <h2 className="app-task-list__section">{`${groupedByCategory[key].length} ${key} tasks`}</h2>
+                <h2 className="app-task-list__section">{`${numberOfTasks} ${isPriority(key)} ${
+                  numberOfTasks < 2 ? 'task' : 'tasks'
+                }`}</h2>
                 {groupedByCategory[key].map((task) => (
                   <TaskListItem
                     key={task.id}
@@ -50,6 +62,7 @@ TaskList.propTypes = {
       name: PropTypes.string.isRequired,
     })
   ),
+  groupBy: PropTypes.string.isRequired,
 };
 
 export default TaskList;

--- a/client/src/pages/tasks/components/TaskList.test.jsx
+++ b/client/src/pages/tasks/components/TaskList.test.jsx
@@ -16,6 +16,7 @@ describe('TaskList', () => {
             id: '1',
             name: 'test',
             due: '19/03/2020',
+            businessKey: 'test',
           },
         ]}
       />

--- a/client/src/pages/tasks/components/TaskList.test.jsx
+++ b/client/src/pages/tasks/components/TaskList.test.jsx
@@ -5,7 +5,7 @@ import TaskList from './TaskList';
 
 describe('TaskList', () => {
   it('renders without crashing', () => {
-    shallow(<TaskList />);
+    shallow(<TaskList groupBy="category" />);
   });
 
   it('can click on a task', () => {
@@ -19,6 +19,7 @@ describe('TaskList', () => {
             businessKey: 'test',
           },
         ]}
+        groupBy="category"
       />
     );
 

--- a/client/src/pages/tasks/components/TaskListItem.jsx
+++ b/client/src/pages/tasks/components/TaskListItem.jsx
@@ -8,7 +8,7 @@ import { useKeycloak } from '@react-keycloak/web';
 
 dayjs.extend(relativeTime);
 
-const TaskListItem = ({ id, due, name, assignee }) => {
+const TaskListItem = ({ id, due, name, assignee, businessKey }) => {
   const [keycloak] = useKeycloak();
   const currentUser = keycloak.tokenParsed.email;
   const isOverDue = () => {
@@ -74,7 +74,7 @@ const TaskListItem = ({ id, due, name, assignee }) => {
   return (
     <div className="govuk-grid-row govuk-!-margin-bottom-3">
       <div className="govuk-grid-column-one-half govuk-!-margin-bottom-3">
-        <span className="govuk-caption-m">{id}</span>
+        <span className="govuk-caption-m">{businessKey}</span>
         <span className="govuk-!-font-size-19 govuk-!-font-weight-bold">
           <Link
             className="govuk-link govuk-!-font-size-19"
@@ -107,6 +107,7 @@ TaskListItem.propTypes = {
   due: PropTypes.string.isRequired,
   name: PropTypes.string.isRequired,
   assignee: PropTypes.string,
+  businessKey: PropTypes.string.isRequired,
 };
 
 export default TaskListItem;

--- a/client/src/pages/tasks/components/TaskListItem.test.jsx
+++ b/client/src/pages/tasks/components/TaskListItem.test.jsx
@@ -9,12 +9,14 @@ dayjs.extend(relativeTime);
 
 describe('TaskListItem', () => {
   it('can render without error', () => {
-    shallow(<TaskListItem id="1" due="19/03/2020" name="test" assignee="test" />);
+    shallow(
+      <TaskListItem id="1" due="19/03/2020" name="test" assignee="test" businessKey="test" />
+    );
   });
 
   it('can click on a task', () => {
     const wrapper = mount(
-      <TaskListItem id="1" due="19/03/2020" name="test" assignee="test" />
+      <TaskListItem id="1" due="19/03/2020" name="test" assignee="test" businessKey="test" />
     );
 
     expect(wrapper.find(Link).at(0).props().href).toBe('/tasks/1');
@@ -22,9 +24,8 @@ describe('TaskListItem', () => {
 
   it('can render "Overdue" if task due date is in the past', () => {
     const wrapper = mount(
-      <TaskListItem id="1" due="2020/03/19" name="test" assignee="test" />
+      <TaskListItem id="1" due="2020/03/19" name="test" assignee="test" businessKey="test" />
     );
-
     const taskDue = wrapper
       .find('div[className="govuk-grid-column-one-third govuk-!-margin-bottom-3"]')
       .at(0);
@@ -34,8 +35,9 @@ describe('TaskListItem', () => {
 
   it('can render "Due" if task due date is in the future', () => {
     const tomorrow = dayjs().add(1, 'day').format();
-    const wrapper = mount(<TaskListItem id="1" due={tomorrow} name="test" assignee="test" />);
-
+    const wrapper = mount(
+      <TaskListItem id="1" due={tomorrow} name="test" assignee="test" businessKey="test" />
+    );
     const taskDue = wrapper
       .find('div[className="govuk-grid-column-one-third govuk-!-margin-bottom-3"]')
       .at(0);

--- a/client/src/pages/tasks/routes.js
+++ b/client/src/pages/tasks/routes.js
@@ -24,7 +24,7 @@ const routes = mount({
   '/:taskId': map((request, context) =>
     withAuthentication(
       route({
-        title: context.t('pages.task.yours.title'),
+        title: context.t('pages.task.title'),
         view: <TaskPage taskId={request.params.taskId} />,
       })
     )

--- a/client/src/pages/tasks/utils.js
+++ b/client/src/pages/tasks/utils.js
@@ -1,8 +1,11 @@
 export const formatPriority = (priority) => {
   if (priority === 50) {
     return 'Low';
-  } if (priority === 100) {
-    return 'Medium';
   }
-  return 'High';
+  if (priority === 100) {
+    return 'Medium';
+  } if (priority === 150) {
+    return 'High';
+  }
+  return null;
 };

--- a/client/src/pages/tasks/utils.js
+++ b/client/src/pages/tasks/utils.js
@@ -1,0 +1,8 @@
+export const formatPriority = (priority) => {
+  if (priority === 50) {
+    return 'Low';
+  } if (priority === 100) {
+    return 'Medium';
+  }
+  return 'High';
+};


### PR DESCRIPTION
### AC
Users should be able to group tasks by category, bf reference (business key), priority and assignee

### Updated
- Added api call to `/process-instance` to associate a business key with each task and updated `TaskListPage.test.jsx` to reflect the extra call
- Refactored `TaskListPage.test.jsx` slightly moving `mockData` higher in scope so other tests can access it (given more assertions will be added - they will)
- Added assertions to test grouping in `TaskListPage.test.jsx`
- Updated `TaskFilters.jsx` bf reference option value to `businessKey` as this matches the property name in the reponse returned in the `/process-instance` call
- Passed `groupBy` state to `TaskList` and created the task groupings dynamically
- Changed pluralisation of task depending on number of tasks in the rendered groups
- Added a `utils.js` file for potentially reusable functions within tasks i.e. `formatPriority` return correct `priority` label depending on the `priority` value

### Notes
- Will add further tests soon an a separate PR

### To test
*If able to run cop-ui local (docker containers etc.):*
 - Pull and run cop-ui
 - Login
 - Submit at least 2 forms (record border event can be submitted pending form changes, this may require making officer details not mandatory in order to complete the form and submit successfully).
 - Navigate to `/tasks`
 - You should see the tasks grouped by default to category
 - Try each option from the Group by dropdown
 - You should see tasks grouped correctly (currently this is restricted by the type of forms you can submit i.e. grouping by category will always be Border Event if only Record Border Event is the only type of form that can be submitted)