### PR TITLE
COP-2810 Search by task name

### DIFF
--- a/client/.eslintrc.json
+++ b/client/.eslintrc.json
@@ -36,6 +36,12 @@
       "rules": {
         "max-len": 0
       }
+    },
+    {
+      "files": ["TasksListPage.jsx"],
+      "rules": {
+        "no-param-reassign": "off"
+      }
     }
   ],
   "rules": {

--- a/client/src/pages/tasks/TasksListPage.jsx
+++ b/client/src/pages/tasks/TasksListPage.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useKeycloak } from '@react-keycloak/web';
 import axios from 'axios';
@@ -26,7 +26,6 @@ const TasksListPage = ({ taskType }) => {
   });
   const isMounted = useIsMounted();
   const axiosInstance = useAxios();
-  const dataRef = useRef(data.tasks);
   const handleFilters = (e) => {
     setFilters({ ...filters, [e.target.name]: e.target.value });
   };
@@ -75,72 +74,82 @@ const TasksListPage = ({ taskType }) => {
                   assignee: keycloak.tokenParsed.email,
                 },
               ],
-            },
-          });
-          // This generates a unique list of process definition ids to use for a call to camunda for task categories
-          const processDefinitionIds = _.uniq(
-            tasksResponse.data.map((task) => task.processDefinitionId)
-          );
-          const definitionResponse = await axiosInstance({
-            method: 'GET',
-            url: '/camunda/engine-rest/process-definition',
-            params: {
-              processDefinitionIdIn: processDefinitionIds.toString(),
-            },
-          });
-          // This generates a unique list of process instance ids to use for a call to camunda for task business keys
-          const processInstanceIds = _.uniq(
-            tasksResponse.data.map((task) => task.processInstanceId)
-          );
-          const processInstanceResponse = await axiosInstance({
-            method: 'POST',
-            url: '/camunda/engine-rest/process-instance',
-            data: {
-              processInstanceIds,
+              nameLike: `%${filters.search}%`,
             },
           });
 
-          if (isMounted.current) {
-            const merged = _.values(
-              _.merge(_.keyBy(tasksResponse.data, 'id'), _.keyBy(dataRef.current, 'id'))
-            );
-
-            if (definitionResponse.data && definitionResponse.data.length !== 0) {
-              merged.forEach((task) => {
-                const processDefinition = _.find(
-                  definitionResponse.data,
-                  (definition) => definition.id === task.processDefinitionId
-                );
-                const processInstance = _.find(
-                  processInstanceResponse.data,
-                  (instance) => instance.id === task.processInstanceId
-                );
-
-                if (processDefinition) {
-                  // eslint-disable-next-line no-param-reassign
-                  task.category = processDefinition.category;
-                }
-                if (processInstance) {
-                  // eslint-disable-next-line no-param-reassign
-                  task.businessKey = processInstance.businessKey;
-                }
-              });
-            }
-
-            dataRef.current = merged;
+          /* If the response from /camunda/engine-rest/task is an empty array, no need to make requests when task list is empty 
+          otherwise this will cause /process-instance call to return an error (no process instance ids in the json body). We don't 
+          want to show an alert if the search string yields no tasks - this is not an api error */
+          if (tasksResponse.data.length === 0) {
             setData({
               isLoading: false,
-              tasks: merged,
-              total: taskCountResponse.data.count,
+              tasks: [],
+              total: 0,
               page: data.page,
               maxResults: data.maxResults,
             });
+          } else {
+            // This generates a unique list of process definition ids to use for a call to camunda for task categories
+            const processDefinitionIds = _.uniq(
+              tasksResponse.data.map((task) => task.processDefinitionId)
+            );
+            const definitionResponse = await axiosInstance({
+              method: 'GET',
+              url: '/camunda/engine-rest/process-definition',
+              params: {
+                processDefinitionIdIn: processDefinitionIds.toString(),
+              },
+            });
+            // This generates a unique list of process instance ids to use for a call to camunda for task business keys
+            const processInstanceIds = _.uniq(
+              tasksResponse.data.map((task) => task.processInstanceId)
+            );
+            const processInstanceResponse = await axiosInstance({
+              method: 'POST',
+              url: '/camunda/engine-rest/process-instance',
+              data: {
+                processInstanceIds,
+              },
+            });
+
+            if (isMounted.current) {
+              if (definitionResponse.data && definitionResponse.data.length !== 0) {
+                tasksResponse.data.forEach((task) => {
+                  const processDefinition = _.find(
+                    definitionResponse.data,
+                    (definition) => definition.id === task.processDefinitionId
+                  );
+                  const processInstance = _.find(
+                    processInstanceResponse.data,
+                    (instance) => instance.id === task.processInstanceId
+                  );
+
+                  if (processDefinition) {
+                    // eslint-disable-next-line no-param-reassign
+                    task.category = processDefinition.category;
+                  }
+                  if (processInstance) {
+                    // eslint-disable-next-line no-param-reassign
+                    task.businessKey = processInstance.businessKey;
+                  }
+                });
+              }
+
+              setData({
+                isLoading: false,
+                tasks: tasksResponse.data,
+                total: taskCountResponse.data.count,
+                page: data.page,
+                maxResults: data.maxResults,
+              });
+            }
           }
         } catch (e) {
           setData({
             isLoading: false,
-            tasks: dataRef.current,
-            total: 0,
+            tasks: [],
+            total: data.total,
             page: data.page,
             maxResults: data.maxResults,
           });

--- a/client/src/pages/tasks/TasksListPage.jsx
+++ b/client/src/pages/tasks/TasksListPage.jsx
@@ -127,7 +127,7 @@ const TasksListPage = ({ taskType }) => {
                 _.merge(_.keyBy(tasksResponse.data, 'id'), _.keyBy(dataRef.current, 'id'))
               );
 
-              if (definitionResponse.data && definitionResponse.data.length !== 0) {
+              if (definitionResponse.data && definitionResponse.data.length) {
                 merged.forEach((task) => {
                   const processDefinition = _.find(
                     definitionResponse.data,
@@ -139,11 +139,9 @@ const TasksListPage = ({ taskType }) => {
                   );
 
                   if (processDefinition) {
-                    // eslint-disable-next-line no-param-reassign
                     task.category = processDefinition.category;
                   }
                   if (processInstance) {
-                    // eslint-disable-next-line no-param-reassign
                     task.businessKey = processInstance.businessKey;
                   }
                 });

--- a/client/src/pages/tasks/TasksListPage.jsx
+++ b/client/src/pages/tasks/TasksListPage.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useKeycloak } from '@react-keycloak/web';
 import axios from 'axios';
@@ -26,6 +26,7 @@ const TasksListPage = ({ taskType }) => {
   const maxResults = 20;
   const isMounted = useIsMounted();
   const axiosInstance = useAxios();
+  const dataRef = useRef();
   const handleFilters = (e) => {
     setFilters({ ...filters, [e.target.name]: e.target.value });
   };
@@ -122,8 +123,12 @@ const TasksListPage = ({ taskType }) => {
             });
 
             if (isMounted.current) {
+              const merged = _.values(
+                _.merge(_.keyBy(tasksResponse.data, 'id'), _.keyBy(dataRef.current, 'id'))
+              );
+
               if (definitionResponse.data && definitionResponse.data.length !== 0) {
-                tasksResponse.data.forEach((task) => {
+                merged.forEach((task) => {
                   const processDefinition = _.find(
                     definitionResponse.data,
                     (definition) => definition.id === task.processDefinitionId
@@ -144,9 +149,11 @@ const TasksListPage = ({ taskType }) => {
                 });
               }
 
+              dataRef.current = merged;
+
               setData({
                 isLoading: false,
-                tasks: tasksResponse.data,
+                tasks: merged,
               });
               setTaskCount(taskCountResponse.data.count);
             }

--- a/client/src/pages/tasks/TasksListPage.test.jsx
+++ b/client/src/pages/tasks/TasksListPage.test.jsx
@@ -164,8 +164,8 @@ describe('TasksListPage', () => {
 
     await waitFor(() => {
       // Check if the grouping title has the correct number of tasks associated with it for categories, the number shown is correspondant with the number of tasks pulled from the api call. Categories is the default grouping when component has mounted
-      expect(screen.getByText('10 test tasks')).toBeTruthy();
-      expect(screen.getByText('2 enhance tasks')).toBeTruthy();
+      expect(screen.getByText('test 10 tasks')).toBeTruthy();
+      expect(screen.getByText('enhance 2 tasks')).toBeTruthy();
     });
 
     // Grab groupByDropdown after initial assertions, cannot define this before the await as the component has not mounted at that point
@@ -175,23 +175,23 @@ describe('TasksListPage', () => {
 
     await waitFor(() => {
       // Same as category assertions but with priority
-      expect(screen.getByText('1 Low task')).toBeTruthy();
-      expect(screen.getByText('10 Medium tasks')).toBeTruthy();
-      expect(screen.getByText('1 High task')).toBeTruthy();
+      expect(screen.getByText('Low 1 task')).toBeTruthy();
+      expect(screen.getByText('Medium 10 tasks')).toBeTruthy();
+      expect(screen.getByText('High 1 task')).toBeTruthy();
     });
 
     fireEvent.change(groupByDropDown, { target: { value: 'assignee' } });
 
     await waitFor(() => {
       // Same as category assertions but with assignee, only one assertion here as all the tasks are assigned to john@doe.com
-      expect(screen.getByText('12 john@doe.com tasks')).toBeTruthy();
+      expect(screen.getByText('john@doe.com 12 tasks')).toBeTruthy();
     });
 
     fireEvent.change(groupByDropDown, { target: { value: 'businessKey' } });
 
     await waitFor(() => {
-      expect(screen.getByText('10 TEST-BUSINESS-KEY0 tasks')).toBeTruthy();
-      expect(screen.getByText('2 TEST-BUSINESS-KEY1 tasks')).toBeTruthy();
+      expect(screen.getByText('TEST-BUSINESS-KEY0 10 tasks')).toBeTruthy();
+      expect(screen.getByText('TEST-BUSINESS-KEY1 2 tasks')).toBeTruthy();
     });
   });
 });

--- a/client/src/pages/tasks/components/TaskList.jsx
+++ b/client/src/pages/tasks/components/TaskList.jsx
@@ -29,7 +29,7 @@ const TaskList = ({ tasks, groupBy }) => {
                     borderTop: 'none',
                   }}
                 />
-                <h2 className="app-task-list__section">{`${numberOfTasks} ${isPriority(key)} ${
+                <h2 className="app-task-list__section">{`${isPriority(key)} ${numberOfTasks} ${
                   numberOfTasks < 2 ? 'task' : 'tasks'
                 }`}</h2>
                 {tasksGroupedBy[key].map((task) => (


### PR DESCRIPTION
### AC
User is able to search for a task by name

### Updated
- Split out `data` state in order keep only directly related data together i.e. maxResults is now a constant as it's value never changed
- Added `filter.search` to request payload to both `tasksResponse` and `taskCountResponse` to allow for search functionality
- Added `taskTypePayload` which decides the type of tasks to search for (either your tasks or your teams tasks)
- Swapped the group name and number of tasks in each group around to match COPv1 UI

### Notes
- API calls on the dashboard need to be revisited for the task count to ensure they are accurate and reflective of their respective task counts

### To test
- Pull and run cop-ui locally (docker containers etc)
- Login
- Submit forms (if able to do so)
- Navigate to /tasks
- Enter the name of the task you want to search
- If the task exists under the name you searched you should see it rendered, otherwise you should not see the task