### PR TITLE
Make context objects available to forms

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -10,7 +10,7 @@ import { initAll } from 'govuk-frontend';
 import Layout from './components/layout';
 import routes from './routes';
 import ApplicationSpinner from './components/ApplicationSpinner';
-import { useFetchTeam } from './utils/hooks';
+import { useFetchStaffId, useFetchTeam } from './utils/hooks';
 
 if (window.ENVIRONMENT_CONFIG) {
   // eslint-disable-next-line no-console
@@ -46,6 +46,7 @@ const RouterView = () => {
 
   initAll();
   useFetchTeam();
+  useFetchStaffId();
 
   return initialized ? (
     <Router

--- a/client/src/components/form/DisplayForm.jsx
+++ b/client/src/components/form/DisplayForm.jsx
@@ -8,6 +8,7 @@ import gds from '@digitalpatterns/formio-gds-template';
 import Loader from '@highpoint/react-loader-advanced';
 import { BLACK, WHITE } from 'govuk-colours';
 import { AlertContext } from '../../utils/AlertContext';
+import { TeamContext } from '../../utils/TeamContext';
 import { augmentRequest, interpolate } from '../../utils/formioSupport';
 import Logger from '../../utils/logger';
 import ApplicationSpinner from '../ApplicationSpinner';
@@ -32,6 +33,31 @@ const DisplayForm = ({
   }`;
 
   const [keycloak] = useKeycloak();
+  const {
+    authServerUrl: url,
+    realm,
+    refreshToken,
+    subject,
+    token: accessToken,
+    tokenParsed: {
+      adelphi_number: adelphi,
+      dateofleaving,
+      delegate_email: delegateEmails,
+      email,
+      family_name: familyName,
+      given_name: givenName,
+      grade_id: gradeId,
+      groups,
+      line_manager_email: linemanagerEmail,
+      location_id: defaultlocationid,
+      name,
+      phone,
+      realm_access: { roles },
+      team_id: teamid,
+      session_state: sessionId,
+    },
+  } = keycloak;
+
   /* istanbul ignore next */
   Formio.baseUrl = host;
   Formio.projectUrl = host;
@@ -45,6 +71,8 @@ const DisplayForm = ({
     submitted: false,
   });
 
+  const { team } = useContext(TeamContext);
+
   const contexts = {
     data: {
       environmentContext: {
@@ -52,6 +80,51 @@ const DisplayForm = ({
         privateUiUrl: window.location.origin,
         referenceDataUrl: '/refdata',
         workflowUrl: '/camunda',
+      },
+      extendedStaffDetailsContext: {
+        delegateEmails,
+        email,
+        linemanagerEmail,
+        name,
+      },
+      keycloakContext: {
+        accessToken,
+        adelphi,
+        email,
+        familyName,
+        givenName,
+        gradeId,
+        locationId: defaultlocationid,
+        phone,
+        realm,
+        refreshToken,
+        roles,
+        sessionId,
+        subject,
+        url,
+      },
+      shiftDetailsDataContext: {
+        email,
+        locationid: defaultlocationid,
+        phone,
+        roles,
+        team,
+        teamid,
+      },
+      staffDetailsDataContext: {
+        adelphi,
+        dateofleaving,
+        defaultlocationid,
+        defaultteam: team,
+        defaultteamid: teamid,
+        email,
+        firstname: givenName,
+        gradeid: gradeId,
+        groups,
+        locationid: defaultlocationid,
+        phone,
+        surname: familyName,
+        teamid,
       },
     },
   };
@@ -189,6 +262,7 @@ const DisplayForm = ({
               showCancel: true,
             },
             beforeSubmit: (submission, next) => {
+              // eslint-disable-next-line no-shadow
               const { versionId, id, title, name } = form;
               // eslint-disable-next-line no-param-reassign
               submission.data.form = {

--- a/client/src/components/form/DisplayForm.jsx
+++ b/client/src/components/form/DisplayForm.jsx
@@ -9,6 +9,7 @@ import Loader from '@highpoint/react-loader-advanced';
 import { BLACK, WHITE } from 'govuk-colours';
 import { AlertContext } from '../../utils/AlertContext';
 import { TeamContext } from '../../utils/TeamContext';
+import { StaffIdContext } from '../../utils/StaffIdContext';
 import { augmentRequest, interpolate } from '../../utils/formioSupport';
 import Logger from '../../utils/logger';
 import ApplicationSpinner from '../ApplicationSpinner';
@@ -72,11 +73,13 @@ const DisplayForm = ({
   });
 
   const { team } = useContext(TeamContext);
+  const { staffId: staffid } = useContext(StaffIdContext);
 
   const contexts = {
     data: {
       environmentContext: {
         attachmentServiceUrl: '/files',
+        operationalDataUrl: '/opdata',
         privateUiUrl: window.location.origin,
         referenceDataUrl: '/refdata',
         workflowUrl: '/camunda',
@@ -123,6 +126,7 @@ const DisplayForm = ({
         groups,
         locationid: defaultlocationid,
         phone,
+        staffid,
         surname: familyName,
         teamid,
       },

--- a/client/src/index.jsx
+++ b/client/src/index.jsx
@@ -5,11 +5,14 @@ import './i18n';
 import App from './App';
 import * as serviceWorker from './serviceWorker';
 import { TeamContextProvider } from './utils/TeamContext';
+import { StaffIdContextProvider } from './utils/StaffIdContext';
 
 ReactDOM.render(
   <React.StrictMode>
     <TeamContextProvider>
-      <App />
+      <StaffIdContextProvider>
+        <App />
+      </StaffIdContextProvider>
     </TeamContextProvider>
   </React.StrictMode>,
   document.getElementById('root')

--- a/client/src/utils/StaffIdContext.js
+++ b/client/src/utils/StaffIdContext.js
@@ -1,0 +1,19 @@
+import React, { createContext, useState } from 'react';
+import PropTypes from 'prop-types';
+
+export const StaffIdContext = createContext({
+  staffId: {},
+  setStaffId: () => {},
+});
+
+export const StaffIdContextProvider = ({ children }) => {
+  const [staffId, setStaffId] = useState(null);
+
+  return (
+    <StaffIdContext.Provider value={{ staffId, setStaffId }}>{children}</StaffIdContext.Provider>
+  );
+};
+
+StaffIdContextProvider.propTypes = {
+  children: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.node), PropTypes.node]).isRequired,
+};

--- a/client/src/utils/StaffIdContext.test.js
+++ b/client/src/utils/StaffIdContext.test.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import { StaffIdContextProvider } from './StaffIdContext';
+
+describe('StaffIdContext', () => {
+  it('can render components without crashing', async () => {
+    const wrapper = await mount(
+      <StaffIdContextProvider>
+        <div>Hello</div>
+      </StaffIdContextProvider>
+    );
+    expect(wrapper).toBeDefined();
+  });
+});

--- a/client/src/utils/hooks.js
+++ b/client/src/utils/hooks.js
@@ -6,6 +6,7 @@ import { useCurrentRoute } from 'react-navi';
 import Logger from './logger';
 import { AlertContext } from './AlertContext';
 import { TeamContext } from './TeamContext';
+import { StaffIdContext } from './StaffIdContext';
 
 export const useAxios = () => {
   const [keycloak, initialized] = useKeycloak();
@@ -106,6 +107,40 @@ export const useFetchTeam = () => {
       source.cancel('Cancelling request');
     };
   }, [axiosInstance, initialized, isMounted, keycloak, setTeam]);
+};
+
+export const useFetchStaffId = () => {
+  const [keycloak, initialized] = useKeycloak();
+  const axiosInstance = useAxios();
+  const isMounted = useIsMounted();
+  const { setStaffId } = useContext(StaffIdContext);
+  useEffect(() => {
+    const source = axios.CancelToken.source();
+    if (initialized) {
+      const {
+        tokenParsed: { email },
+      } = keycloak;
+      const fetchData = async () => {
+        try {
+          const response = await axiosInstance.get(`opdata/v2/staff?filter=email=eq.${email}`, {
+            cancelToken: source.token,
+          });
+          if (isMounted.current) {
+            const { staffid: staffId } = response.data[0];
+            setStaffId(staffId);
+          }
+        } catch (error) {
+          if (isMounted.current) {
+            setStaffId(null);
+          }
+        }
+      };
+      fetchData();
+    }
+    return () => {
+      source.cancel('Cancelling request');
+    };
+  }, [axiosInstance, initialized, isMounted, keycloak, setStaffId]);
 };
 
 export default useIsMounted;

--- a/client/src/utils/hooks.test.js
+++ b/client/src/utils/hooks.test.js
@@ -3,9 +3,10 @@ import PropTypes from 'prop-types';
 import axios from 'axios';
 import MockAdapter from 'axios-mock-adapter';
 import { renderHook } from '@testing-library/react-hooks';
-import { useAxios, useFetchTeam, useIsMounted } from './hooks';
+import { useAxios, useFetchTeam, useFetchStaffId, useIsMounted } from './hooks';
 import Logger from './logger';
 import { TeamContext } from './TeamContext';
+import { StaffIdContext } from './StaffIdContext';
 
 jest.mock('./logger', () => ({
   error: jest.fn(),
@@ -15,7 +16,7 @@ jest.mock('react', () => {
   const ActualReact = require.requireActual('react');
   return {
     ...ActualReact,
-    useContext: () => ({ setAlertContext: jest.fn(), setTeam: jest.fn() }),
+    useContext: () => ({ setAlertContext: jest.fn(), setTeam: jest.fn(), setStaffId: jest.fn() }),
   };
 });
 
@@ -52,15 +53,13 @@ describe('axios hooks', () => {
   });
 
   it('can fetch team', async () => {
-    mockAxios
-      .onGet('/refdata/v2/entities/team?filter=id=eq.21')
-      .reply(200, {
-        data: [
-          {
-            branchid: 23,
-          },
-        ],
-      });
+    mockAxios.onGet('/refdata/v2/entities/team?filter=id=eq.21').reply(200, {
+      data: [
+        {
+          branchid: 23,
+        },
+      ],
+    });
     const { Provider } = TeamContext;
     const wrapper = ({ children }) => (
       <Provider value={{ team: { branchid: 23 } }}>{children}</Provider>
@@ -69,5 +68,21 @@ describe('axios hooks', () => {
       children: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.node), PropTypes.node]).isRequired,
     };
     renderHook(() => useFetchTeam(), { wrapper });
+  });
+
+  it('can fetch staffid', async () => {
+    mockAxios.onGet('/opdata/v2/staff').reply(200, {
+      data: [
+        {
+          staffid: 'abc',
+        },
+      ],
+    });
+    const { Provider } = StaffIdContext;
+    const wrapper = ({ children }) => <Provider value={{ staffId: 'abc' }}>{children}</Provider>;
+    wrapper.propTypes = {
+      children: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.node), PropTypes.node]).isRequired,
+    };
+    renderHook(() => useFetchStaffId(), { wrapper });
   });
 });

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -37,6 +37,10 @@ zuul:
       path: /form/**
       strip-prefix: false
       url: ${formApi.url:http://localhost:4000}
+    opdata-service:
+      path: /opdata/**
+      strip-prefix: true
+      url: ${opDataService.url:http://api-cop.lodev.xyz}
     workflow-service:
       strip-prefix: false
       path: /camunda/**


### PR DESCRIPTION
This is intended to make all expected context objects and properties available to forms, except `shifthistoryid`. We're aware this is used in some forms and will need to investigate why, because shifts are being dropped. There is one linting exception inline which I will revisit later. We also need to bear in mind for the future that users who have not been through onboarding will not have a `staffid`.