### PR TITLE
COP-2813 Enable pagination on task list pages

### DIFF
--- a/client/src/pages/tasks/TasksListPage.jsx
+++ b/client/src/pages/tasks/TasksListPage.jsx
@@ -40,8 +40,10 @@ const TasksListPage = ({ taskType }) => {
     const loadTasks = async () => {
       if (axiosInstance) {
         try {
-          /* taskTypePayload uses the taskType prop to query either the user assigned tasks or 
-          their assigned and group assigned tasks */
+          /*
+           * taskTypePayload uses the taskType prop to query either the user assigned tasks or
+           * their assigned and group assigned tasks
+           */
           const taskTypePayload =
             taskType === 'yours'
               ? {
@@ -89,9 +91,11 @@ const TasksListPage = ({ taskType }) => {
             },
           });
 
-          /* If the response from /camunda/engine-rest/task is an empty array, no need to make requests when task list is empty 
-          otherwise this will cause /process-instance call to return an error (no process instance ids in the json body). We don't 
-          want to show an alert if the search string yields no tasks - this is not an api error */
+          /*
+           * If the response from /camunda/engine-rest/task is an empty array, no need to make requests when task list is empty
+           * otherwise this will cause /process-instance call to return an error (no process instance ids in the json body). We don't
+           * want to show an alert if the search string yields no tasks - this is not an api error
+           */
           if (tasksResponse.data.length === 0) {
             setData({
               isLoading: false,

--- a/client/src/pages/tasks/TasksListPage.jsx
+++ b/client/src/pages/tasks/TasksListPage.jsx
@@ -199,14 +199,14 @@ const TasksListPage = ({ taskType }) => {
       <div className="govuk-grid-row">
         <div className="govuk-grid-column-full">
           <TaskList tasks={data.tasks} groupBy={filters.groupBy} />
-          {data.tasks.length ? (
+          {data.tasks.length && (
             <TaskPagination
               page={page}
               setPage={setPage}
               taskCount={taskCount}
               maxResults={maxResults}
             />
-          ) : null}
+          )}
         </div>
       </div>
     </>

--- a/client/src/pages/tasks/TasksListPage.jsx
+++ b/client/src/pages/tasks/TasksListPage.jsx
@@ -199,12 +199,14 @@ const TasksListPage = ({ taskType }) => {
       <div className="govuk-grid-row">
         <div className="govuk-grid-column-full">
           <TaskList tasks={data.tasks} groupBy={filters.groupBy} />
-          <TaskPagination
-            page={page}
-            setPage={setPage}
-            taskCount={taskCount}
-            maxResults={maxResults}
-          />
+          {data.tasks.length ? (
+            <TaskPagination
+              page={page}
+              setPage={setPage}
+              taskCount={taskCount}
+              maxResults={maxResults}
+            />
+          ) : null}
         </div>
       </div>
     </>

--- a/client/src/pages/tasks/TasksListPage.jsx
+++ b/client/src/pages/tasks/TasksListPage.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useRef } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useKeycloak } from '@react-keycloak/web';
 import axios from 'axios';
@@ -8,6 +8,7 @@ import ApplicationSpinner from '../../components/ApplicationSpinner';
 import { useIsMounted, useAxios } from '../../utils/hooks';
 import TaskList from './components/TaskList';
 import TaskFilters from './components/TaskFilters';
+import TaskPagination from './components/TaskPagination';
 
 const TasksListPage = ({ taskType }) => {
   const { t } = useTranslation();
@@ -26,7 +27,6 @@ const TasksListPage = ({ taskType }) => {
   const maxResults = 20;
   const isMounted = useIsMounted();
   const axiosInstance = useAxios();
-  const dataRef = useRef();
   const handleFilters = (e) => {
     setFilters({ ...filters, [e.target.name]: e.target.value });
   };
@@ -123,12 +123,8 @@ const TasksListPage = ({ taskType }) => {
             });
 
             if (isMounted.current) {
-              const merged = _.values(
-                _.merge(_.keyBy(tasksResponse.data, 'id'), _.keyBy(dataRef.current, 'id'))
-              );
-
               if (definitionResponse.data && definitionResponse.data.length) {
-                merged.forEach((task) => {
+                tasksResponse.data.forEach((task) => {
                   const processDefinition = _.find(
                     definitionResponse.data,
                     (definition) => definition.id === task.processDefinitionId
@@ -147,11 +143,9 @@ const TasksListPage = ({ taskType }) => {
                 });
               }
 
-              dataRef.current = merged;
-
               setData({
                 isLoading: false,
-                tasks: merged,
+                tasks: tasksResponse.data,
               });
               setTaskCount(taskCountResponse.data.count);
             }
@@ -201,23 +195,12 @@ const TasksListPage = ({ taskType }) => {
       <div className="govuk-grid-row">
         <div className="govuk-grid-column-full">
           <TaskList tasks={data.tasks} groupBy={filters.groupBy} />
-          {taskCount > maxResults && data.tasks.length < taskCount ? (
-            <ul className="govuk-list">
-              <li>
-                <a
-                  id="loadMore"
-                  onClick={async (e) => {
-                    e.preventDefault();
-                    setPage(page + maxResults);
-                  }}
-                  className="govuk-link"
-                  href={`/tasks?firstResult=${page + maxResults}&maxResults=${maxResults}`}
-                >
-                  {t('pages.forms.list.load-more')}
-                </a>
-              </li>
-            </ul>
-          ) : null}
+          <TaskPagination
+            page={page}
+            setPage={setPage}
+            taskCount={taskCount}
+            maxResults={maxResults}
+          />
         </div>
       </div>
     </>

--- a/client/src/pages/tasks/TasksListPage.test.jsx
+++ b/client/src/pages/tasks/TasksListPage.test.jsx
@@ -66,7 +66,10 @@ describe('TasksListPage', () => {
   });
 
   it('can group tasks correctly', async () => {
-    // Add more objects with different processDefinitionIds to map different categories to them. Also added differing priorities to test priority grouping
+    /*
+     * Add more objects with different processDefinitionIds to map different categories to them.
+     * Also added differing priorities to test priority grouping
+     */
     mockData = mockData.concat([
       {
         id: 'enhance-category',
@@ -118,7 +121,11 @@ describe('TasksListPage', () => {
     const { container } = render(<TasksListPage />);
 
     await waitFor(() => {
-      // Check if the grouping title has the correct number of tasks associated with it for categories, the number shown is correspondant with the number of tasks pulled from the api call. Categories is the default grouping when component has mounted
+      /*
+       * Check if the grouping title has the correct number of tasks associated with it for categories,
+       * the number shown is correspondant with the number of tasks pulled from the api call.
+       * Categories is the default grouping when component has mounted
+       */
       expect(screen.getByText('test 10 tasks')).toBeTruthy();
       expect(screen.getByText('enhance 2 tasks')).toBeTruthy();
     });

--- a/client/src/pages/tasks/TasksListPage.test.jsx
+++ b/client/src/pages/tasks/TasksListPage.test.jsx
@@ -65,51 +65,6 @@ describe('TasksListPage', () => {
     expect(wrapper.find(TaskList).exists()).toBe(true);
   });
 
-  it('can click on load more', async () => {
-    // This call is required in order to map a category to each task in mockData
-    mockAxios.onGet('/camunda/engine-rest/process-definition').reply(200, [
-      {
-        category: 'test',
-        id: 'processDefinitionId0',
-      },
-    ]);
-    mockAxios.onPost('/camunda/engine-rest/task').reply(200, mockData);
-    mockAxios.onPost('/camunda/engine-rest/task/count').reply(200, {
-      count: 100,
-    });
-    // This call is required in order to map a business key to each task in mockData
-    mockAxios.onPost('/camunda/engine-rest/process-instance').reply(200, [
-      {
-        businessKey: 'TEST-BUSINESS-KEY',
-        id: 'processDefinitionId0',
-      },
-    ]);
-    const wrapper = await mount(<TasksListPage />);
-
-    await act(async () => {
-      await Promise.resolve(wrapper);
-      await new Promise((resolve) => setImmediate(resolve));
-      await wrapper.update();
-    });
-
-    expect(wrapper.find('a[id="loadMore"]').exists()).toBe(true);
-
-    await act(async () => {
-      await wrapper
-        .find('a[id="loadMore"]')
-        .at(0)
-        .simulate('click', {
-          preventDefault: () => {},
-        });
-
-      await wrapper.update();
-    });
-
-    // Following assertions look to see how many axios calls are made in the course of the test. In this instance, 2 GET requests and 6 POST requests are expected
-    expect(mockAxios.history.get.length).toBe(2);
-    expect(mockAxios.history.post.length).toBe(6);
-  });
-
   it('can group tasks correctly', async () => {
     // Add more objects with different processDefinitionIds to map different categories to them. Also added differing priorities to test priority grouping
     mockData = mockData.concat([

--- a/client/src/pages/tasks/components/TaskPagination.jsx
+++ b/client/src/pages/tasks/components/TaskPagination.jsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import TaskPaginationButton from './TaskPaginationButton';
+
+const TaskPagination = ({ setPage, page, maxResults, taskCount }) => {
+  return (
+    <div className="govuk-grid-row">
+      <div className="govuk-grid-column-one-quarter">
+        <TaskPaginationButton
+          isButtonDisabled={page - maxResults < 0}
+          setPage={setPage}
+          newPageValue={0}
+          text="&laquo; First"
+        />
+      </div>
+      <div className="govuk-grid-column-one-quarter">
+        <TaskPaginationButton
+          isButtonDisabled={page - maxResults < 0}
+          setPage={setPage}
+          newPageValue={page - maxResults}
+          text="&lsaquo; Previous"
+        />
+      </div>
+      <div className="govuk-grid-column-one-quarter">
+        <TaskPaginationButton
+          isButtonDisabled={page + maxResults >= taskCount}
+          setPage={setPage}
+          newPageValue={page + maxResults}
+          text="Next &rsaquo;"
+        />
+      </div>
+      <div className="govuk-grid-column-one-quarter">
+        <TaskPaginationButton
+          isButtonDisabled={page + maxResults >= taskCount}
+          setPage={setPage}
+          newPageValue={Math.floor(taskCount / maxResults) * maxResults}
+          text="Last &raquo;"
+        />
+      </div>
+    </div>
+  );
+};
+
+TaskPagination.propTypes = {
+  setPage: PropTypes.func.isRequired,
+  page: PropTypes.number.isRequired,
+  maxResults: PropTypes.number.isRequired,
+  taskCount: PropTypes.number.isRequired,
+};
+
+export default TaskPagination;

--- a/client/src/pages/tasks/components/TaskPagination.test.jsx
+++ b/client/src/pages/tasks/components/TaskPagination.test.jsx
@@ -4,12 +4,14 @@ import TaskPagination from './TaskPagination';
 
 describe('TaskPagination', () => {
   const mockSetPage = jest.fn();
+  window.scrollTo = jest.fn();
 
   it('can render without error', () => {
     render(<TaskPagination setPage={mockSetPage} page={0} maxResults={10} taskCount={100} />);
   });
 
   it('can disable pagination buttons', () => {
+    // On first page with 10 results per page and 100 tasks overall
     const { rerender } = render(
       <TaskPagination setPage={mockSetPage} page={0} maxResults={10} taskCount={100} />
     );
@@ -22,6 +24,7 @@ describe('TaskPagination', () => {
 
     expect(mockSetPage).not.toHaveBeenCalled();
 
+    // On last page with 10 results per page and 100 tasks overall
     rerender(<TaskPagination setPage={mockSetPage} page={90} maxResults={10} taskCount={100} />);
 
     fireEvent.click(screen.getByText('Next ›'));
@@ -42,16 +45,20 @@ describe('TaskPagination', () => {
 
     expect(mockSetPage).toHaveBeenCalled();
 
+    // Need to clear mockSetPage to prevent each time to prevent false positives
+    mockSetPage.mockClear();
     fireEvent.click(screen.getByText('Last »'));
 
     expect(mockSetPage).toHaveBeenCalled();
 
     rerender(<TaskPagination setPage={mockSetPage} page={90} maxResults={10} taskCount={100} />);
 
+    mockSetPage.mockClear();
     fireEvent.click(screen.getByText('« First'));
 
     expect(mockSetPage).toHaveBeenCalled();
 
+    mockSetPage.mockClear();
     fireEvent.click(screen.getByText('‹ Previous'));
 
     expect(mockSetPage).toHaveBeenCalled();

--- a/client/src/pages/tasks/components/TaskPagination.test.jsx
+++ b/client/src/pages/tasks/components/TaskPagination.test.jsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import TaskPagination from './TaskPagination';
+
+describe('TaskPagination', () => {
+  const mockSetPage = jest.fn();
+
+  it('can render without error', () => {
+    render(<TaskPagination setPage={mockSetPage} page={0} maxResults={10} taskCount={100} />);
+  });
+
+  it('can disable pagination buttons', () => {
+    const { rerender } = render(
+      <TaskPagination setPage={mockSetPage} page={0} maxResults={10} taskCount={100} />
+    );
+
+    fireEvent.click(screen.getByText('« First'));
+
+    expect(mockSetPage).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByText('‹ Previous'));
+
+    expect(mockSetPage).not.toHaveBeenCalled();
+
+    rerender(<TaskPagination setPage={mockSetPage} page={90} maxResults={10} taskCount={100} />);
+
+    fireEvent.click(screen.getByText('Next ›'));
+
+    expect(mockSetPage).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByText('Last »'));
+
+    expect(mockSetPage).not.toHaveBeenCalled();
+  });
+
+  it('can click on pagination buttons successfully', () => {
+    const { rerender } = render(
+      <TaskPagination setPage={mockSetPage} page={0} maxResults={10} taskCount={100} />
+    );
+
+    fireEvent.click(screen.getByText('Next ›'));
+
+    expect(mockSetPage).toHaveBeenCalled();
+
+    fireEvent.click(screen.getByText('Last »'));
+
+    expect(mockSetPage).toHaveBeenCalled();
+
+    rerender(<TaskPagination setPage={mockSetPage} page={90} maxResults={10} taskCount={100} />);
+
+    fireEvent.click(screen.getByText('« First'));
+
+    expect(mockSetPage).toHaveBeenCalled();
+
+    fireEvent.click(screen.getByText('‹ Previous'));
+
+    expect(mockSetPage).toHaveBeenCalled();
+  });
+});

--- a/client/src/pages/tasks/components/TaskPaginationButton.jsx
+++ b/client/src/pages/tasks/components/TaskPaginationButton.jsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { scrollToMainContent } from '../../../utils/scrollToMainContent';
+
+const TaskPaginationButton = ({ isButtonDisabled, setPage, newPageValue, text }) => {
+  const handleClick = () => {
+    setPage(newPageValue);
+    scrollToMainContent();
+  };
+
+  return (
+    <button
+      type="submit"
+      data-module="govuk-button"
+      className={`govuk-button govuk-!-width-full ${
+        isButtonDisabled ? 'govuk-button--disabled' : ''
+      }`}
+      disabled={isButtonDisabled ? 'disabled' : false}
+      onClick={handleClick}
+    >
+      {text}
+    </button>
+  );
+};
+
+TaskPaginationButton.propTypes = {
+  isButtonDisabled: PropTypes.bool.isRequired,
+  setPage: PropTypes.func.isRequired,
+  newPageValue: PropTypes.number.isRequired,
+  text: PropTypes.string.isRequired,
+};
+
+export default TaskPaginationButton;

--- a/client/src/pages/tasks/components/TaskPaginationButton.jsx
+++ b/client/src/pages/tasks/components/TaskPaginationButton.jsx
@@ -2,7 +2,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const TaskPaginationButton = ({ isButtonDisabled, setPage, newPageValue, text }) => {
-  const handleClick = () => {
+  const handleClick = (e) => {
+    e.target.blur();
     setPage(newPageValue);
     window.scrollTo(0, 0);
   };

--- a/client/src/pages/tasks/components/TaskPaginationButton.jsx
+++ b/client/src/pages/tasks/components/TaskPaginationButton.jsx
@@ -1,11 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { scrollToMainContent } from '../../../utils/scrollToMainContent';
 
 const TaskPaginationButton = ({ isButtonDisabled, setPage, newPageValue, text }) => {
-  const handleClick = (e) => {
+  const handleClick = () => {
     setPage(newPageValue);
-    scrollToMainContent(e);
+    window.scrollTo(0, 0);
   };
 
   return (

--- a/client/src/pages/tasks/components/TaskPaginationButton.jsx
+++ b/client/src/pages/tasks/components/TaskPaginationButton.jsx
@@ -3,9 +3,9 @@ import PropTypes from 'prop-types';
 import { scrollToMainContent } from '../../../utils/scrollToMainContent';
 
 const TaskPaginationButton = ({ isButtonDisabled, setPage, newPageValue, text }) => {
-  const handleClick = () => {
+  const handleClick = (e) => {
     setPage(newPageValue);
-    scrollToMainContent();
+    scrollToMainContent(e);
   };
 
   return (

--- a/client/src/pages/tasks/components/TaskPaginationButton.test.jsx
+++ b/client/src/pages/tasks/components/TaskPaginationButton.test.jsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import TaskPaginationButton from './TaskPaginationButton';
+
+describe('TaskPaginationButton', () => {
+  const mockSetPage = jest.fn();
+  it('can render without error', () => {
+    render(
+      <TaskPaginationButton
+        isButtonDisabled={false}
+        setPage={mockSetPage}
+        newPageValue={20}
+        text="test"
+      />
+    );
+  });
+});


### PR DESCRIPTION
### AC
User should be able to navigate through the tasks list with the pagination

### Updated
- Removed `useRef` and and `loadMore` from `TasksListPage` as they aren't required for pagination functionality
- Removed load more tasks assertion from `TasksListPage.test`
- Added `TaskPagination` component to `TasksListPage` that is conditionally rendered depending on the number of tasks returned
- Added `TaskPaginationButton` to allow for conditionally disable buttons
- Added assertions to `TaskPagination.text.jsx`, focused on testing if the buttons were correctly disabled under certain circumstances and vice versa
- Format comments

### To test
- Pull and run cop locally
- Login
- If 21+ tasks are already present then navigate to /tasks, if not, you will need to submit forms until this task number is reached
- *You should see the pagination buttons underneath the task list with '< previous'  and '<< first' being greyed out*
- Click on the 'last >>' button
- *You should be taken to the last page successfully with 'next >'  and 'last >>' being greyed out*
- Click on the '<< first' button
- *You should be taken to the first page successfully '< previous'  and '<< first' being greyed out*
- Next and previous are relative to the amount of tasks you have however they should also be greyed out when at either the first or last page of task results

