### PR TITLE
Cop 2811

### DIFF
--- a/client/src/pages/tasks/components/TaskListItem.test.jsx
+++ b/client/src/pages/tasks/components/TaskListItem.test.jsx
@@ -1,28 +1,34 @@
 import React from 'react';
 import { mount, shallow } from 'enzyme';
+import { render, fireEvent, screen, waitFor } from '@testing-library/react';
+import MockAdapter from 'axios-mock-adapter';
+import axios from 'axios';
 import { Link } from 'react-navi';
 import dayjs from 'dayjs';
 import relativeTime from 'dayjs/plugin/relativeTime';
 import TaskListItem from './TaskListItem';
+import { mockNavigate } from '../../../setupTests';
 
 dayjs.extend(relativeTime);
 
 describe('TaskListItem', () => {
+  const mockAxios = new MockAdapter(axios);
+
   it('can render without error', () => {
     shallow(
-      <TaskListItem id="1" due="19/03/2020" name="test" assignee="test" businessKey="test" />
+      <TaskListItem id="1" due="2020/03/19" name="test" assignee="test" businessKey="test" />
     );
   });
 
   it('can click on a task', () => {
     const wrapper = mount(
-      <TaskListItem id="1" due="19/03/2020" name="test" assignee="test" businessKey="test" />
+      <TaskListItem id="1" due="2020/03/19" name="test" assignee="test" businessKey="test" />
     );
 
     expect(wrapper.find(Link).at(0).props().href).toBe('/tasks/1');
   });
 
-  it('can render "Overdue" if task due date is in the past', () => {
+  it('renders "Overdue" if task due date is in the past', () => {
     const wrapper = mount(
       <TaskListItem id="1" due="2020/03/19" name="test" assignee="test" businessKey="test" />
     );
@@ -33,7 +39,7 @@ describe('TaskListItem', () => {
     expect(taskDue.text()).toMatch(/Overdue/);
   });
 
-  it('can render "Due" if task due date is in the future', () => {
+  it('renders "Due" if task due date is in the future', () => {
     const tomorrow = dayjs().add(1, 'day').format();
     const wrapper = mount(
       <TaskListItem id="1" due={tomorrow} name="test" assignee="test" businessKey="test" />
@@ -43,5 +49,48 @@ describe('TaskListItem', () => {
       .at(0);
 
     expect(taskDue.text()).toMatch(/Due in a day/);
+  });
+
+  it('can claim a task not assigned to the current user', async () => {
+    mockAxios.onPost('/camunda/engine-rest/task/1/claim').reply(200, {
+      count: 1,
+    });
+    // In the setupTests mocks, the default current user is "test"
+    render(
+      <TaskListItem
+        id="1"
+        due="2020/03/19"
+        name="testName"
+        assignee="testAssignee"
+        businessKey="testKey"
+      />
+    );
+
+    expect(screen.getByText('Claim')).toBeTruthy();
+
+    fireEvent.click(screen.getByText('Claim'));
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith('/tasks/1');
+    });
+  });
+
+  it('can unclaim a task assigned to the current user', async () => {
+    mockAxios.onPost('/camunda/engine-rest/task/1/unclaim').reply(200, {
+      count: 1,
+    });
+    // In the setupTests mocks, the default current user is "test"
+    render(
+      <TaskListItem id="1" due="2020/03/19" name="testName" assignee="test" businessKey="testKey" />
+    );
+
+    expect(screen.getByText('Unclaim')).toBeTruthy();
+
+    fireEvent.click(screen.getByText('Unclaim'));
+
+    await waitFor(() => {
+      expect(screen.queryByText('Unclaim')).toBeFalsy();
+      expect(screen.getByText('Claim')).toBeTruthy();
+    });
   });
 });


### PR DESCRIPTION
### AC
The user is able to claim and unclaim a task successfully

### Updated
- Added api calls to the `handleClaim` and `handleUnclaim` functions in `TaskListItem.jsx`
- Added `unclaimActionMade ` to determine if Unclaim has been pressed, in which case, update the UI to reflect this action
- Added tests for the changes made to `TaskListItem.jsx`

### To test
- Pull and run cop locally
- Login
- Submit a form (intel ref is the most convenient currently)
- Navigate to `/tasks`
- Claim the task you've just made by clicking on the 'Claim' button
- *You should be navigated to the single task page of the task you just claimed* 
- Navigate back to the `/tasks`
- *You should see the task you have just claimed now have the 'Unclaim' button*
- Unclaim the task you just claimed by clicking on the 'Unclaim' button
- *You should see the UI update with the 'Unclaim' button now being 'Claim'* 