### PR TITLE
COP-3774 : Enable follow on forms to load

### DIFF
--- a/client/src/pages/forms/hooks.js
+++ b/client/src/pages/forms/hooks.js
@@ -1,4 +1,5 @@
 import { useCallback, useContext } from 'react';
+import { useKeycloak } from '@react-keycloak/web';
 import { useTranslation } from 'react-i18next';
 import { useNavigation } from 'react-navi';
 import { useAxios } from '../../utils/hooks';
@@ -9,6 +10,8 @@ export default () => {
   const { t } = useTranslation();
   const { setAlertContext } = useContext(AlertContext);
   const navigation = useNavigation();
+  const [keycloak] = useKeycloak();
+  const currentUser = keycloak.tokenParsed.email;
 
   const submitForm = useCallback(
     (submission, formInfo, id, handleOnFailure) => {
@@ -29,20 +32,35 @@ export default () => {
             businessKey: submission.data.businessKey,
           })
           .then(async () => {
-            setAlertContext({
-              type: 'form-submission',
-              status: 'successful',
-              message: t('pages.form.submission.success-message'),
-              reference: `${submission.data.businessKey}`,
-            });
-            await navigation.navigate('/');
+            axiosInstance
+              .get(
+                `/camunda/engine-rest/task?processInstanceBusinessKey=${submission.data.businessKey}`
+              )
+              .then((response) => {
+                // This will automatically open the next form available (if one exists for this user)
+                // We can only ever open one task in this manner and so always take the first available
+                if (response.data.length > 0 && response.data[0].assignee === currentUser) {
+                  navigation.navigate(`/tasks/${response.data[0].id}`);
+                } else {
+                  setAlertContext({
+                    type: 'form-submission',
+                    status: 'successful',
+                    message: t('pages.form.submission.success-message'),
+                    reference: `${submission.data.businessKey}`,
+                  });
+                  navigation.navigate('/');
+                }
+              })
+              .catch(() => {
+                handleOnFailure();
+              });
           })
           .catch(() => {
             handleOnFailure();
           });
       }
     },
-    [axiosInstance, navigation, setAlertContext, t]
+    [axiosInstance, navigation, setAlertContext, t, currentUser]
   );
 
   return {

--- a/client/src/pages/forms/hooks.test.jsx
+++ b/client/src/pages/forms/hooks.test.jsx
@@ -1,55 +1,80 @@
-import axios from 'axios';
-import { renderHook, act } from '@testing-library/react-hooks';
-import MockAdapter from 'axios-mock-adapter';
 import React from 'react';
+import { renderHook, act } from '@testing-library/react-hooks';
+import axios from 'axios';
+import MockAdapter from 'axios-mock-adapter';
+import { waitFor } from '@testing-library/react';
+import { AlertContextProvider } from '../../utils/AlertContext';
 import apiHooks from './hooks';
 import { mockNavigate } from '../../setupTests';
-import { AlertContextProvider } from '../../utils/AlertContext';
 
 jest.mock('../../utils/logger', () => ({
   error: jest.fn(),
 }));
 
+jest.mock('react', () => {
+  const ActualReact = require.requireActual('react');
+  return {
+    ...ActualReact,
+    useContext: () => ({ setAlertContext: jest.fn(), setTeam: jest.fn(), setStaffId: jest.fn() }),
+  };
+});
+
 describe('hooks', () => {
   const mockAxios = new MockAdapter(axios);
-
-  it('can handle submit', async () => {
-    mockAxios
-      .onPost('/camunda/engine-rest/process-definition/key/formId/submit-form')
-      .reply(200, {});
-    // eslint-disable-next-line react/prop-types
-    const wrapper = ({ children }) => <AlertContextProvider>{children}</AlertContextProvider>;
-    const { result } = renderHook(() => apiHooks(), { wrapper });
-    await act(async () => {
-      result.current.submitForm(
-        {
-          data: {
-            test: 'test',
-            form: {
-              submittedBy: 'test@digital.homeoffice.gov.uk',
-            },
-          },
-        },
-        {
-          data: {
-            name: 'test',
-          },
-        },
-        'formId',
-        () => {}
-      );
-    });
-    expect(mockNavigate).toBeCalled();
+  beforeEach(() => {
+    mockAxios.reset();
+    mockNavigate.mockReset();
   });
 
-  it('can calls handle failure ', async () => {
+  it('can handle a failure to submit a form', async () => {
     mockAxios
       .onPost('/camunda/engine-rest/process-definition/key/formId/submit-form')
       .reply(500, {});
+    const handleOnFailure = jest.fn();
     // eslint-disable-next-line react/prop-types
     const wrapper = ({ children }) => <AlertContextProvider>{children}</AlertContextProvider>;
-    const handleFailure = jest.fn();
     const { result } = renderHook(() => apiHooks(), { wrapper });
+
+    await act(async () => {
+      result.current.submitForm(
+        // data for 'submission' variable
+        {
+          data: {
+            test: 'test',
+            form: {
+              submittedBy: 'test@digital.homeoffice.gov.uk',
+            },
+          },
+        },
+        // data for 'formInfo'
+        {
+          data: {
+            name: 'test',
+          },
+        },
+        // data for 'id'
+        'formId',
+        // for 'handleOnFailure'
+        handleOnFailure
+      );
+    });
+    expect(handleOnFailure).toBeCalled();
+  });
+
+  it('can handle successful submit, but failed get tasks', async () => {
+    // eslint-disable-next-line react/prop-types
+    const wrapper = ({ children }) => <AlertContextProvider>{children}</AlertContextProvider>;
+    const { result } = renderHook(() => apiHooks(), { wrapper });
+    const handleOnFailure = jest.fn();
+
+    mockAxios
+      .onPost('/camunda/engine-rest/process-definition/key/formId/submit-form')
+      .reply(200, {});
+    mockAxios
+      .onGet('/camunda/engine-rest/task?processInstanceBusinessKey=testBusinessKey')
+      .reply(500, {});
+
+    // Successful submit
     await act(async () => {
       result.current.submitForm(
         {
@@ -66,10 +91,131 @@ describe('hooks', () => {
           },
         },
         'formId',
-        handleFailure
+        handleOnFailure
       );
     });
+    // This will be the handleOnFailure for the onGet call
+    expect(handleOnFailure).toBeCalled();
+  });
 
-    expect(handleFailure).toBeCalled();
+  it('can handle successful submit, and go to the task if task exists for this user', async () => {
+    const { result } = renderHook(() => apiHooks());
+
+    mockAxios
+      .onPost('/camunda/engine-rest/process-definition/key/formId/submit-form')
+      .reply(200, {});
+    mockAxios
+      .onGet('/camunda/engine-rest/task?processInstanceBusinessKey=testBusinessKey')
+      .reply(200, [
+        {
+          id: 'testId',
+          assignee: 'test', // this is declared in setupTests.js
+        },
+      ]);
+
+    result.current.submitForm(
+      // submission
+      {
+        data: {
+          test: 'test',
+          businessKey: 'testBusinessKey',
+          form: {
+            submittedBy: 'test@digital.homeoffice.gov.uk',
+          },
+        },
+      },
+      // formInfo
+      {
+        data: {
+          name: 'test',
+        },
+      },
+      // id
+      'formId',
+      () => {}
+    );
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith('/tasks/testId');
+    });
+  });
+
+  it('can handle successful submit, and go to dashboard with confirmation if no further task exists for this businessKey', async () => {
+    const { result } = renderHook(() => apiHooks());
+
+    mockAxios
+      .onPost('/camunda/engine-rest/process-definition/key/formId/submit-form')
+      .reply(200, {});
+    mockAxios
+      .onGet('/camunda/engine-rest/task?processInstanceBusinessKey=testBusinessKey')
+      .reply(200, []);
+
+    result.current.submitForm(
+      // submission
+      {
+        data: {
+          test: 'test',
+          businessKey: 'testBusinessKey',
+          form: {
+            submittedBy: 'test@digital.homeoffice.gov.uk',
+          },
+        },
+      },
+      // formInfo
+      {
+        data: {
+          name: 'test',
+        },
+      },
+      // id
+      'formId',
+      () => {}
+    );
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith('/');
+    });
+  });
+
+  it('can handle successful submit, and go to dashboard with confirmation if a task exists, but not for this user', async () => {
+    const { result } = renderHook(() => apiHooks());
+
+    mockAxios
+      .onPost('/camunda/engine-rest/process-definition/key/formId/submit-form')
+      .reply(200, {});
+    mockAxios
+      .onGet('/camunda/engine-rest/task?processInstanceBusinessKey=testBusinessKey')
+      .reply(200, [
+        {
+          id: 'testId',
+          assignee: 'notThisUser',
+        },
+      ]);
+
+    result.current.submitForm(
+      // submission
+      {
+        data: {
+          test: 'test',
+          businessKey: 'testBusinessKey',
+          form: {
+            submittedBy: 'test@digital.homeoffice.gov.uk',
+          },
+        },
+      },
+      // formInfo
+      {
+        data: {
+          name: 'test',
+        },
+      },
+      // id
+      'formId',
+      () => {}
+    );
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith('/');
+    });
   });
 });


### PR DESCRIPTION
### AC
When a form is submitted, if the next task to be done is assigned to the current user, that task(form) should load immediately.

### Updated
- Added api call to check for tasks and load task page if found
- Added tests

### Notes
- There is now an error showing related to cash/items/firearms seized but it does not seem to be related to this function so will look at it separately

### To test
- Pull and run cop locally
- Login
- Submit a collect-event-at-border form for Air Passengers
- > on submit you should see the People form load
- Submit an intel-referral form
- > on submit you should be returned to the dashboard with a businessKey
- Check group tasks 
- > you should see the Enhance task for this businessKey (you need /devTesting role)
- Submit a Corona virus form
- > you should be returned to the dashboard with a businessKey (there are no further tasks)