### PR TITLE
COP-2811 Change task query parameters

### DIFF
--- a/client/src/pages/home/index.jsx
+++ b/client/src/pages/home/index.jsx
@@ -33,7 +33,7 @@ const Home = () => {
           orQueries: [
             {
               candidateGroups: keycloak.tokenParsed.groups,
-              assignee: keycloak.tokenParsed.email,
+              includeAssignedTasks: true,
             },
           ],
         },

--- a/client/src/pages/tasks/TasksListPage.jsx
+++ b/client/src/pages/tasks/TasksListPage.jsx
@@ -50,19 +50,15 @@ const TasksListPage = ({ taskType }) => {
                   assignee: keycloak.tokenParsed.email,
                 }
               : {
-                  assignee: keycloak.tokenParsed.email,
                   candidateGroups: keycloak.tokenParsed.groups,
+                  includeAssignedTasks: true,
                 };
           const taskCountResponse = await axiosInstance({
             method: 'POST',
             url: '/camunda/engine-rest/task/count',
             cancelToken: source.token,
             data: {
-              orQueries: [
-                {
-                  ...taskTypePayload,
-                },
-              ],
+              ...taskTypePayload,
               nameLike: `%${filters.search}%`,
             },
           });
@@ -82,11 +78,7 @@ const TasksListPage = ({ taskType }) => {
                   sortOrder,
                 },
               ],
-              orQueries: [
-                {
-                  ...taskTypePayload,
-                },
-              ],
+              ...taskTypePayload,
               nameLike: `%${filters.search}%`,
             },
           });

--- a/client/src/pages/tasks/components/TaskListItem.jsx
+++ b/client/src/pages/tasks/components/TaskListItem.jsx
@@ -50,7 +50,7 @@ const TaskListItem = ({ id, due, name, assignee, businessKey }) => {
     const source = axios.CancelToken.source();
     await axiosInstance({
       method: 'POST',
-      url: `/camunda/engine-rest/task/${id}/claim`,
+      url: `/camunda/engine-rest/task/${id}/assignee`,
       cancelToken: source.token,
       data: {
         userId: currentUser,

--- a/client/src/pages/tasks/components/TaskListItem.test.jsx
+++ b/client/src/pages/tasks/components/TaskListItem.test.jsx
@@ -52,7 +52,7 @@ describe('TaskListItem', () => {
   });
 
   it('can claim a task not assigned to the current user', async () => {
-    mockAxios.onPost('/camunda/engine-rest/task/1/claim').reply(200, {
+    mockAxios.onPost('/camunda/engine-rest/task/1/assignee').reply(200, {
       count: 1,
     });
     // In the setupTests mocks, the default current user is "test"


### PR DESCRIPTION
Changed the query parameters for the task list and task count. Before this change, tasks that were assigned to a someone else other than the current user were not visible.