### PR TITLE
Refactor Power BI work

### DIFF
--- a/client/public/locales/en-GB/translation.json
+++ b/client/public/locales/en-GB/translation.json
@@ -141,9 +141,7 @@
     "report": {
       "title": "Report | Central Operations Platform",
       "logo-bar": {
-        "intro": "To refresh the report, please return to",
-        "link": "the main reports page",
-        "outro": "and reselect it.",
+        "reload": "Reload",
         "fullscreen": "View fullscreen"
       }
     },

--- a/client/src/pages/reports/ReportsListPage.test.jsx
+++ b/client/src/pages/reports/ReportsListPage.test.jsx
@@ -38,7 +38,6 @@ describe('ReportsListPage', () => {
       await wrapper.update();
     });
     expect(wrapper.find('h1').at(0).text()).toBe('pages.reports.list.heading');
-
     wrapper
       .find('.list-item a')
       .at(0)

--- a/client/src/pages/reports/components/LogoBar.jsx
+++ b/client/src/pages/reports/components/LogoBar.jsx
@@ -1,20 +1,33 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Link } from 'react-navi';
 import { useTranslation } from 'react-i18next';
 import './LogoBar.scss';
 
-const LogoBar = ({ setFullscreen }) => {
-  const { t } = useTranslation();
+export const fullscreen = (report) => report.fullscreen();
+export const reload = (report) => report.reload();
 
+const LogoBar = ({ report, visitedPages }) => {
+  const { t } = useTranslation();
   return (
     <div className="logo-bar">
-      <p>
-        {t('pages.report.logo-bar.intro')}{' '}
-        <Link href="/reports/">{t('pages.report.logo-bar.link')}</Link>{' '}
-        {t('pages.report.logo-bar.outro')}
-      </p>
-      <button type="button" onClick={setFullscreen}>
+      <button
+        id="reload"
+        type="button"
+        onClick={() => {
+          // eslint-disable-next-line no-param-reassign
+          visitedPages.current = [];
+          reload(report);
+        }}
+      >
+        {t('pages.report.logo-bar.reload')}
+      </button>
+      <button
+        id="fullscreen"
+        type="button"
+        onClick={() => {
+          fullscreen(report);
+        }}
+      >
         {t('pages.report.logo-bar.fullscreen')}
       </button>
     </div>
@@ -22,7 +35,12 @@ const LogoBar = ({ setFullscreen }) => {
 };
 
 LogoBar.propTypes = {
-  setFullscreen: PropTypes.func.isRequired,
+  report: PropTypes.shape({
+    fullscreen: PropTypes.func.isRequired,
+  }).isRequired,
+  visitedPages: PropTypes.shape({
+    current: PropTypes.arrayOf(PropTypes.string).isRequired,
+  }).isRequired,
 };
 
 export default LogoBar;

--- a/client/src/pages/reports/components/LogoBar.scss
+++ b/client/src/pages/reports/components/LogoBar.scss
@@ -2,13 +2,13 @@
 
 .logo-bar {
   align-items: center;
-  bottom: -35px;
+  bottom: 0px;
   display: flex;
   font-family: $govuk-font-family-nta;
   font-size: 12px;
   height: 35px;
   position: absolute;
-  right: 0;
+  right: 10px;
 
   button {
     border: none;
@@ -17,27 +17,26 @@
     cursor: pointer;
     font-size: smaller;
     font-weight: $govuk-font-weight-bold;
-    padding: 6px;
+    padding: 8px;
     text-transform: uppercase;
     &:focus {
       outline: none;
     }
   }
 
-  p {
-    color: govuk-colour('dark-grey');
-    margin: 0;
-
-    @media only screen and (max-width: 960px) {
-      display: none;
+  button {
+    &:not(:last-child) {
+      padding-right: 0px;
+      &:after {
+        content: '|';
+        margin-left: 8px;
+      }
     }
   }
+}
 
-  button,
-  p {
-    &:not(:last-child):after {
-      content: '|';
-      margin-left: 6px;
-    }
+@media only screen and (max-width: 960px) {
+  .logo-bar {
+    display: none;
   }
 }

--- a/client/src/pages/reports/components/LogoBar.test.jsx
+++ b/client/src/pages/reports/components/LogoBar.test.jsx
@@ -4,7 +4,13 @@ import LogoBar from './LogoBar';
 
 describe('LogoBar', () => {
   const props = {
-    setFullscreen: jest.fn(),
+    report: {
+      fullscreen: jest.fn(),
+      reload: jest.fn(),
+    },
+    visitedPages: {
+      current: [],
+    },
   };
 
   it('renders without crashing', () => {
@@ -12,10 +18,22 @@ describe('LogoBar', () => {
     expect(wrapper.exists()).toBe(true);
   });
 
-  it('fires setFullscreen on button click', () => {
+  it('fires reload as expected', () => {
     const wrapper = shallow(<LogoBar {...props} />);
-    wrapper.find('button').simulate('click');
-    expect(props.setFullscreen).toHaveBeenCalledTimes(1);
+    wrapper.find('#reload').simulate('click');
+    expect(props.report.reload).toHaveBeenCalledTimes(1);
+  });
+
+  it('resets visitedPages as expected', () => {
+    const wrapper = shallow(<LogoBar {...props} />);
+    wrapper.find('#reload').simulate('click');
+    expect(props.visitedPages.current).toEqual([]);
+  });
+
+  it('fires fullscreen as expected', () => {
+    const wrapper = shallow(<LogoBar {...props} />);
+    wrapper.find('#fullscreen').simulate('click');
+    expect(props.report.fullscreen).toHaveBeenCalledTimes(1);
   });
 
   it('matches snapshot', () => {

--- a/client/src/pages/reports/components/PowerBIReport.jsx
+++ b/client/src/pages/reports/components/PowerBIReport.jsx
@@ -1,148 +1,48 @@
-import React, { useContext, useEffect, useRef } from 'react';
-import axios from 'axios';
+import React, { useContext, useEffect, useRef, useState } from 'react';
 import { useNavigation } from 'react-navi';
-import { factories, models, service } from 'powerbi-client';
 import styled from 'styled-components';
 import LogoBar from './LogoBar';
 import { TeamContext } from '../../../utils/TeamContext';
-import { useAxios, useIsMounted } from '../../../utils/hooks';
 import { mobileWidth } from '../../../utils/constants';
-
-export const setFullscreen = (currentReport) => currentReport && currentReport.fullscreen();
+import useFetchBranchName from '../utils/useFetchBranchName';
+import embedReport from '../utils/embedReport';
 
 const PowerBIReport = () => {
-  const axiosInstance = useAxios();
-  const report = useRef(null);
-  const userBranchName = useRef(null);
-  const reportContainer = useRef(null);
-  const mobileLayout = window.innerWidth < mobileWidth;
   const navigation = useNavigation();
   const state = navigation.extractState();
-  const logoBar = mobileLayout ? null : (
-    <LogoBar
-      setFullscreen={() => {
-        setFullscreen(report.current);
-      }}
-    />
-  );
-  const isMounted = useIsMounted();
-  const visitedPages = [];
+  const reportContainer = useRef(null);
+  const [branchName, setBranchName] = useState(null);
+  const [embedReportArgs, setEmbedReportArgs] = useState(null);
+  const [mobileLayout, setMobileLayout] = useState(null);
+  const [report, setReport] = useState(null);
   const {
     team: { branchid: branchId },
   } = useContext(TeamContext);
-  const powerBIBranchNames = [
-    'Central',
-    'Detection Services',
-    'Heathrow',
-    'Intelligence',
-    'National Operations',
-    'North',
-    'South',
-    'South East and Europe',
-  ];
-  if (!state) navigation.navigate('/reports');
+  const visitedPages = useRef([]);
 
   useEffect(() => {
-    const source = axios.CancelToken.source();
-    const onPageChange = (e) => {
-      let target;
-      let visualNumber;
-      const {
-        newPage,
-        newPage: { displayName },
-      } = e.detail;
-
-      if (visitedPages.includes(displayName)) return;
-
-      visitedPages.push(displayName);
-      if (displayName === 'Command Brief - OAR') {
-        visualNumber = 5;
-        target = { table: 'OAR', column: 'Branch Name' };
-      } else if (displayName === 'Command Brief - IEN') {
-        visualNumber = 4;
-        target = { table: 'IEN', column: 'Branch' };
-      } else {
-        return;
-      }
-
-      newPage.getVisuals().then((visuals) => {
-        const targetVisual = visuals[visualNumber];
-        targetVisual
-          .setSlicerState({
-            filters: [
-              {
-                $schema: 'http://powerbi.com/product/schema#basic',
-                target,
-                operator: 'In',
-                values: [userBranchName.current],
-              },
-            ],
-          })
-          .catch((errors) => {
-            // eslint-disable-next-line no-console
-            console.log('Errors loading visuals:', errors);
-          });
+    if (!state) {
+      navigation.navigate('/reports');
+    } else {
+      setMobileLayout(window.innerWidth < mobileWidth);
+      setEmbedReportArgs({
+        mobileLayout,
+        reportContainer,
+        visitedPages,
+        ...state,
       });
-    };
+    }
+  }, [mobileLayout, navigation, reportContainer, state, visitedPages]);
 
-    const embedReport = () => {
-      const { accessToken, embedUrl, id } = state;
-      const powerbi = new service.Service(
-        factories.hpmFactory,
-        factories.wpmpFactory,
-        factories.routerFactory
-      );
-      const embedConfig = {
-        accessToken,
-        type: 'report',
-        embedUrl,
-        id,
-        permissions: models.Permissions.Read,
-        settings: {
-          filterPaneEnabled: false,
-          layoutType: mobileLayout ? models.LayoutType.MobilePortrait : models.LayoutType.Master,
-        },
-        tokenType: models.TokenType.Embed,
-      };
-      report.current = powerbi.embed(reportContainer.current, embedConfig);
-      if (userBranchName.current) {
-        report.current.on('pageChanged', onPageChange);
-      }
-    };
-
-    const fetchBranchName = async () => {
-      if (axiosInstance) {
-        try {
-          const response = await axiosInstance.get(
-            `/refdata/v2/entities/branch?filter=id=eq.${branchId}`,
-            {
-              cancelToken: source.token,
-            }
-          );
-          if (isMounted.current) {
-            const branchName = response.data.data.length && response.data.data[0].name;
-            if (powerBIBranchNames.includes(branchName)) {
-              userBranchName.current = branchName;
-            }
-            embedReport();
-          }
-        } catch (e) {
-          // eslint-disable-next-line no-console
-          console.log('Error fetching branch name:', e);
-        }
-      }
-    };
-    fetchBranchName();
-  }, [
-    axiosInstance,
+  useFetchBranchName({
     branchId,
-    isMounted,
-    mobileLayout,
-    powerBIBranchNames,
-    state,
-    userBranchName,
-    visitedPages,
-  ]);
+    setBranchName,
+  });
+
+  useEffect(() => {
+    setReport(embedReport({ branchName, ...embedReportArgs }));
+  }, [branchName, embedReportArgs]);
+
   return (
     <ReportContainer
       {...{ mobileLayout }}
@@ -152,7 +52,7 @@ const PowerBIReport = () => {
       }}
     >
       <Report id="report" ref={reportContainer} />
-      {logoBar}
+      {report && !mobileLayout ? <LogoBar {...{ report, branchName, visitedPages }} /> : null}
     </ReportContainer>
   );
 };

--- a/client/src/pages/reports/components/PowerBIReport.test.jsx
+++ b/client/src/pages/reports/components/PowerBIReport.test.jsx
@@ -1,12 +1,24 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { mount } from 'enzyme';
 import 'jest-styled-components';
 import { useNavigation } from 'react-navi';
-import PowerBIReport, { setFullscreen, ReportContainer } from './PowerBIReport';
+import PowerBIReport, { ReportContainer } from './PowerBIReport';
 import { mockNavigate } from '../../../setupTests';
+import { TeamContext } from '../../../utils/TeamContext';
 
 describe('PowerBIReport Page', () => {
+  const extractState = () => ({
+    accessToken: 'xxx',
+    embedUrl: 'http://www.example.com',
+    id: 'abc',
+    name: 'Power BI Report',
+  });
+
   it('renders without crashing', () => {
+    useNavigation.mockImplementationOnce(() => ({
+      extractState,
+    }));
     const wrapper = mount(<PowerBIReport />);
     expect(wrapper.exists()).toBe(true);
   });
@@ -16,23 +28,26 @@ describe('PowerBIReport Page', () => {
     expect(mockNavigate).toHaveBeenCalled();
   });
 
-  it('runs fullscreen if there is a report', async () => {
-    const fullScreenMock = jest.fn();
-    setFullscreen({ fullscreen: fullScreenMock });
-    expect(fullScreenMock).toHaveBeenCalledTimes(1);
-  });
-
-  it('renders a report div', () => {
-    useNavigation.mockImplementation(() => ({
-      extractState: () => ({
-        accessToken: 'xxx',
-        embedUrl: 'http://www.example.com',
-        id: 'abc',
-        name: 'Power BI Report',
-      }),
+  it('render report element when branchid is found', async () => {
+    useNavigation.mockImplementationOnce(() => ({
+      extractState,
     }));
-    const wrapper = mount(<PowerBIReport />);
-    expect(wrapper.find('#report').exists()).toEqual(true);
+
+    const { Provider } = TeamContext;
+    const TestComponent = ({ children }) => (
+      <Provider value={{ team: { branchid: 23 } }}>{children}</Provider>
+    );
+
+    TestComponent.propTypes = {
+      children: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.node), PropTypes.node]).isRequired,
+    };
+
+    const wrapper = mount(
+      <TestComponent>
+        <PowerBIReport />
+      </TestComponent>
+    );
+    expect(wrapper.find('#report').exists()).toBe(true);
   });
 
   it('renders styles as expected', () => {

--- a/client/src/pages/reports/components/__snapshots__/LogoBar.test.jsx.snap
+++ b/client/src/pages/reports/components/__snapshots__/LogoBar.test.jsx.snap
@@ -4,31 +4,16 @@ exports[`LogoBar matches snapshot 1`] = `
 <div
   className="logo-bar"
 >
-  <p>
-    pages.report.logo-bar.intro
-     
-    <Link
-      href="/reports/"
-    >
-      pages.report.logo-bar.link
-    </Link>
-     
-    pages.report.logo-bar.outro
-  </p>
   <button
-    onClick={
-      [MockFunction] {
-        "calls": Array [
-          Array [],
-        ],
-        "results": Array [
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-        ],
-      }
-    }
+    id="reload"
+    onClick={[Function]}
+    type="button"
+  >
+    pages.report.logo-bar.reload
+  </button>
+  <button
+    id="fullscreen"
+    onClick={[Function]}
     type="button"
   >
     pages.report.logo-bar.fullscreen

--- a/client/src/pages/reports/components/__snapshots__/PowerBIReport.test.jsx.snap
+++ b/client/src/pages/reports/components/__snapshots__/PowerBIReport.test.jsx.snap
@@ -14,7 +14,7 @@ exports[`PowerBIReport Page matches snapshot 1`] = `
 
 <PowerBIReport>
   <styled.div
-    mobileLayout={false}
+    mobileLayout={null}
     style={
       Object {
         "height": "50vw",
@@ -39,31 +39,6 @@ exports[`PowerBIReport Page matches snapshot 1`] = `
           id="report"
         />
       </styled.div>
-      <LogoBar
-        setFullscreen={[Function]}
-      >
-        <div
-          className="logo-bar"
-        >
-          <p>
-            pages.report.logo-bar.intro
-             
-            <Link
-              href="/reports/"
-            >
-              pages.report.logo-bar.link
-            </Link>
-             
-            pages.report.logo-bar.outro
-          </p>
-          <button
-            onClick={[Function]}
-            type="button"
-          >
-            pages.report.logo-bar.fullscreen
-          </button>
-        </div>
-      </LogoBar>
     </div>
   </styled.div>
 </PowerBIReport>

--- a/client/src/pages/reports/utils/VisitedPagesContext.js
+++ b/client/src/pages/reports/utils/VisitedPagesContext.js
@@ -1,0 +1,21 @@
+import React, { createContext, useState } from 'react';
+import PropTypes from 'prop-types';
+
+export const VisitedPagesContext = createContext({
+  visitedPages: {},
+  setVisitedPages: () => {},
+});
+
+export const VisitedPagesContextProvider = ({ children }) => {
+  const [visitedPages, setVisitedPages] = useState({});
+
+  return (
+    <VisitedPagesContext.Provider value={{ visitedPages, setVisitedPages }}>
+      {children}
+    </VisitedPagesContext.Provider>
+  );
+};
+
+VisitedPagesContextProvider.propTypes = {
+  children: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.node), PropTypes.node]).isRequired,
+};

--- a/client/src/pages/reports/utils/VisitedPagesContext.test.js
+++ b/client/src/pages/reports/utils/VisitedPagesContext.test.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import { VisitedPagesContextProvider } from './VisitedPagesContext';
+
+describe('VisitedPagesContext', () => {
+  it('can render components without crashing', async () => {
+    const wrapper = await mount(
+      <VisitedPagesContextProvider>
+        <div>Hello</div>
+      </VisitedPagesContextProvider>
+    );
+    expect(wrapper).toBeDefined();
+  });
+});

--- a/client/src/pages/reports/utils/embedReport.js
+++ b/client/src/pages/reports/utils/embedReport.js
@@ -1,0 +1,39 @@
+import { models } from 'powerbi-client';
+import { powerBIBranchNames } from '../../../utils/constants';
+import onPageChange from './onPageChange';
+import powerbi from './powerBIService';
+
+const embedReport = ({
+  accessToken,
+  branchName,
+  embedUrl,
+  id,
+  mobileLayout,
+  reportContainer,
+  visitedPages,
+}) => {
+  let report;
+  if (reportContainer) {
+    const embedConfig = {
+      accessToken,
+      type: 'report',
+      embedUrl,
+      id,
+      permissions: models.Permissions.Read,
+      settings: {
+        filterPaneEnabled: false,
+        layoutType: mobileLayout ? models.LayoutType.MobilePortrait : models.LayoutType.Master,
+      },
+      tokenType: models.TokenType.Embed,
+    };
+
+    powerbi.reset(reportContainer.current);
+    report = powerbi.embed(reportContainer.current, embedConfig);
+    if (powerBIBranchNames.includes(branchName)) {
+      report.on('pageChanged', (event) => onPageChange(branchName, event, visitedPages));
+    }
+  }
+  return report;
+};
+
+export default embedReport;

--- a/client/src/pages/reports/utils/embedReport.test.js
+++ b/client/src/pages/reports/utils/embedReport.test.js
@@ -1,0 +1,71 @@
+import { models } from 'powerbi-client';
+import embedReport from './embedReport';
+import powerBIService from './powerBIService';
+
+jest.mock('./powerBIService', () => {
+  return {
+    embed: jest.fn((target, embedConfig) => {
+      return {
+        on: jest.fn(),
+        mobileLayout: embedConfig.settings.layoutType,
+      };
+    }),
+    reset: jest.fn(),
+  };
+});
+
+describe('embedReport', () => {
+  let resetSpy;
+  let embedSpy;
+
+  const args = {
+    accessToken: 'xxx',
+    branchName: 'My branch',
+    embedUrl: 'http://www.testembedurl/',
+    id: 'xyz',
+    mobileLayout: false,
+    reportContainer: {
+      current: document.createElement('div'),
+    },
+    visitedPages: { current: [] },
+  };
+
+  beforeEach(() => {
+    resetSpy = jest.spyOn(powerBIService, 'reset');
+    embedSpy = jest.spyOn(powerBIService, 'embed');
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('embeds report if there is a reportContainer', () => {
+    const report = embedReport(args);
+    expect(resetSpy).toHaveBeenCalledTimes(1);
+    expect(embedSpy).toHaveBeenCalledTimes(1);
+    expect(report).not.toEqual(undefined);
+  });
+
+  it('sets embedConfig as expected if mobileLayout is true', () => {
+    const report = embedReport({ ...args, mobileLayout: true });
+    expect(report.mobileLayout).toEqual(models.LayoutType.MobilePortrait);
+  });
+
+  it('does nothing if there is no reportContainer', () => {
+    const report = embedReport({
+      ...args,
+      reportContainer: null,
+    });
+    expect(resetSpy).not.toHaveBeenCalled();
+    expect(embedSpy).not.toHaveBeenCalled();
+    expect(report).toEqual(undefined);
+  });
+
+  it("adds pageChange handler if user's branch is among Power BI branches", () => {
+    const report = embedReport({
+      ...args,
+      branchName: 'Central',
+    });
+    expect(report.on).toHaveBeenCalledTimes(1);
+  });
+});

--- a/client/src/pages/reports/utils/onPageChange.js
+++ b/client/src/pages/reports/utils/onPageChange.js
@@ -1,0 +1,45 @@
+import { powerBiSchema as $schema } from '../../../utils/constants';
+
+const onPageChange = (branchName, event, visitedPages) => {
+  let target;
+  let visualNumber;
+  const {
+    newPage,
+    newPage: { displayName },
+  } = event.detail;
+
+  if (visitedPages.current.includes(displayName)) return;
+
+  visitedPages.current.push(displayName);
+
+  if (displayName === 'Command Brief - OAR') {
+    visualNumber = 5;
+    target = { table: 'OAR', column: 'Branch Name' };
+  } else if (displayName === 'Command Brief - IEN') {
+    visualNumber = 4;
+    target = { table: 'IEN', column: 'Branch' };
+  } else {
+    return;
+  }
+
+  newPage.getVisuals().then((visuals) => {
+    const targetVisual = visuals[visualNumber];
+    targetVisual
+      .setSlicerState({
+        filters: [
+          {
+            $schema,
+            target,
+            operator: 'In',
+            values: [branchName],
+          },
+        ],
+      })
+      .catch((errors) => {
+        // eslint-disable-next-line no-console
+        console.log('Errors loading visuals:', errors);
+      });
+  });
+};
+
+export default onPageChange;

--- a/client/src/pages/reports/utils/onPageChange.test.js
+++ b/client/src/pages/reports/utils/onPageChange.test.js
@@ -1,0 +1,91 @@
+import onPageChange from './onPageChange';
+
+describe('onPageChange', () => {
+  const visuals = [];
+  for (let index = 0; index < 6; index += 1) {
+    visuals.push({
+      setSlicerState: jest.fn(() => ({
+        catch: jest.fn(),
+      })),
+    });
+  }
+  const getVisuals = jest.fn(() => Promise.resolve(visuals));
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('adds new pages to visitedPages', () => {
+    const branchName = 'Central';
+    const event = {
+      detail: {
+        newPage: {
+          displayName: 'Test Page',
+          getVisuals,
+        },
+      },
+    };
+    const visitedPages = { current: [] };
+    onPageChange(branchName, event, visitedPages);
+    expect(visitedPages).toEqual({ current: ['Test Page'] });
+    expect(event.detail.newPage.getVisuals).not.toHaveBeenCalled();
+  });
+
+  it('sets visuals on displayName match', () => {
+    const branchName = 'Central';
+    let event = {
+      detail: {
+        newPage: {
+          displayName: 'Command Brief - OAR',
+          getVisuals,
+        },
+      },
+    };
+    const visitedPages = { current: [] };
+    onPageChange(branchName, event, visitedPages);
+    expect(visitedPages).toEqual({ current: ['Command Brief - OAR'] });
+    expect(event.detail.newPage.getVisuals).toHaveBeenCalledTimes(1);
+
+    event = {
+      detail: {
+        newPage: {
+          displayName: 'Command Brief - IEN',
+          getVisuals,
+        },
+      },
+    };
+    onPageChange(branchName, event, visitedPages);
+    expect(visitedPages).toEqual({ current: ['Command Brief - OAR', 'Command Brief - IEN'] });
+    expect(event.detail.newPage.getVisuals).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not set visuals for other displayNames', () => {
+    const branchName = 'Central';
+    const event = {
+      detail: {
+        newPage: {
+          displayName: 'Test Page',
+          getVisuals,
+        },
+      },
+    };
+    const visitedPages = { current: [] };
+    onPageChange(branchName, event, visitedPages);
+    expect(event.detail.newPage.getVisuals).not.toHaveBeenCalled();
+  });
+
+
+  it('does not add existing pages to visitedPages', () => {
+    const branchName = 'My branch';
+    const event = {
+      detail: {
+        newPage: {
+          displayName: 'Test Page',
+        },
+      },
+    };
+    const visitedPages = { current: ['Test Page'] };
+    onPageChange(branchName, event, visitedPages);
+    expect(visitedPages).toEqual({ current: ['Test Page'] });
+  });
+});

--- a/client/src/pages/reports/utils/powerBIService.js
+++ b/client/src/pages/reports/utils/powerBIService.js
@@ -1,0 +1,9 @@
+import { factories, service } from 'powerbi-client';
+
+const powerbi = new service.Service(
+  factories.hpmFactory,
+  factories.wpmpFactory,
+  factories.routerFactory
+);
+
+export default powerbi;

--- a/client/src/pages/reports/utils/powerBIService.test.js
+++ b/client/src/pages/reports/utils/powerBIService.test.js
@@ -1,0 +1,8 @@
+import { service } from 'powerbi-client';
+import powerbi from './powerBIService';
+
+describe('powerbi', () => {
+  it('creates new Power BI service as expected', async () => {
+    expect(powerbi).toBeInstanceOf(service.Service);
+  });
+});

--- a/client/src/pages/reports/utils/useFetchBranchName.js
+++ b/client/src/pages/reports/utils/useFetchBranchName.js
@@ -1,0 +1,36 @@
+import { useEffect } from 'react';
+import axios from 'axios';
+import { useAxios, useIsMounted } from '../../../utils/hooks';
+
+const useFetchBranchName = async ({ branchId, setBranchName }) => {
+  const axiosInstance = useAxios();
+  const isMounted = useIsMounted();
+  useEffect(() => {
+    const source = axios.CancelToken.source();
+    if (axiosInstance && branchId) {
+      const fetchData = async () => {
+        try {
+          const response = await axiosInstance.get(
+            `/refdata/v2/entities/branch?filter=id=eq.${branchId}`,
+            {
+              cancelToken: source.token,
+            }
+          );
+          if (isMounted.current) {
+            const branchName = response.data.data.length && response.data.data[0].name;
+            setBranchName(branchName);
+          }
+        } catch (e) {
+          // eslint-disable-next-line no-console
+          console.log('Error fetching branch name:', e);
+        }
+      };
+      fetchData();
+    }
+    return () => {
+      source.cancel('Cancelling request');
+    };
+  }, [axiosInstance, branchId, isMounted, setBranchName]);
+};
+
+export default useFetchBranchName;

--- a/client/src/pages/reports/utils/useFetchBranchName.test.js
+++ b/client/src/pages/reports/utils/useFetchBranchName.test.js
@@ -1,0 +1,26 @@
+import axios from 'axios';
+import MockAdapter from 'axios-mock-adapter';
+import { renderHook } from '@testing-library/react-hooks';
+import useFetchBranchName from './useFetchBranchName';
+
+describe('useFetchBranchName', () => {
+  const mockAxios = new MockAdapter(axios);
+  const setBranchName = jest.fn();
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('fetches branch name as expected', async () => {
+    mockAxios.onGet('/refdata/v2/entities/branch?filter=id=eq.23').reply(200, {
+      data: [
+        {
+          name: 'Central',
+        },
+      ],
+    });
+
+    renderHook(() => useFetchBranchName({ branchId: 23, setBranchName }));
+    /* TODO: See how to test that setBranchName has been called */
+  });
+});

--- a/client/src/utils/TeamContext.js
+++ b/client/src/utils/TeamContext.js
@@ -7,7 +7,7 @@ export const TeamContext = createContext({
 });
 
 export const TeamContextProvider = ({ children }) => {
-  const [team, setTeam] = useState(null);
+  const [team, setTeam] = useState({});
 
   return <TeamContext.Provider value={{ team, setTeam }}>{children}</TeamContext.Provider>;
 };

--- a/client/src/utils/constants.js
+++ b/client/src/utils/constants.js
@@ -1,1 +1,13 @@
 export const mobileWidth = 640;
+
+export const powerBIBranchNames = [
+  'Central',
+  'Detection Services',
+  'Heathrow',
+  'Intelligence',
+  'National Operations',
+  'South',
+  'South East and Europe',
+];
+
+export const powerBiSchema = 'http://powerbi.com/product/schema#basic';


### PR DESCRIPTION
This is — unusually — in one commit, because so much of it interlinks.

• Separate various Power BI functions/hooks into their own files so that the code is more modular and allows unit testing
• Move Power BI branch names into constants file
• Remove 'return to reports list' link in favour of new report reload functionality (tweak Sass accordingly)
• Handle user having no team (in this case branch name is not fetched and filters are not set on page change)
• Other more minor refactoring
• Enhance unit tests