### PR TITLE
COP-4201 Persist task filters

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -4391,6 +4391,11 @@
         "randomfill": "^1.0.3"
       }
     },
+    "crypto-js": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-3.3.0.tgz",
+      "integrity": "sha512-DIT51nX0dCfKltpRiXV+/TVZq+Qq2NgF4644+K7Ttnla7zEzqc+kjJyiB96BHNyUTBxyjzRcZYpUdZa+QAqi6Q=="
+    },
     "css": {
       "version": "2.2.4",
       "resolved": "http://localhost:4873/css/-/css-2.2.4.tgz",
@@ -9981,6 +9986,11 @@
         "yallist": "^2.1.2"
       }
     },
+    "lz-string": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.4.4.tgz",
+      "integrity": "sha1-wNjq82BZ9wV5bh40SBHPTEmNOiY="
+    },
     "make-dir": {
       "version": "2.1.0",
       "resolved": "http://localhost:4873/make-dir/-/make-dir-2.1.0.tgz",
@@ -13995,6 +14005,15 @@
             "amdefine": ">=0.0.4"
           }
         }
+      }
+    },
+    "secure-ls": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/secure-ls/-/secure-ls-1.2.6.tgz",
+      "integrity": "sha512-g8vUSKl6elSfyAUHodybnNkuZW+mUYEOWj4SZIDg+xoQ1dq5ddktBoOFrtxQBUl88ZyAJOtGWQ1PRaOxkTAuZQ==",
+      "requires": {
+        "crypto-js": "^3.1.6",
+        "lz-string": "^1.4.4"
       }
     },
     "select-hose": {

--- a/client/package.json
+++ b/client/package.json
@@ -34,6 +34,7 @@
     "react-navi": "^0.14.3",
     "react-navi-helmet": "^0.14.3",
     "react-scripts": "3.4.1",
+    "secure-ls": "^1.2.6",
     "styled-components": "^5.1.0",
     "uuid": "^8.1.0"
   },

--- a/client/src/pages/tasks/TasksListPage.jsx
+++ b/client/src/pages/tasks/TasksListPage.jsx
@@ -9,13 +9,14 @@ import { useIsMounted, useAxios } from '../../utils/hooks';
 import TaskList from './components/TaskList';
 import TaskFilters from './components/TaskFilters';
 import TaskPagination from './components/TaskPagination';
+import secureLocalStorage from '../../utils/SecureLocalStorage';
 
 const TasksListPage = ({ taskType }) => {
   const { t } = useTranslation();
   const [keycloak] = useKeycloak();
   const [filters, setFilters] = useState({
-    sortBy: 'asc-dueDate',
-    groupBy: 'category',
+    sortBy: secureLocalStorage.setInitialValue(`${taskType}-tasksSortBy`, 'asc-dueDate'),
+    groupBy: secureLocalStorage.setInitialValue(`${taskType}-tasksGroupBy`, 'category'),
     search: '',
   });
   const [data, setData] = useState({
@@ -28,7 +29,12 @@ const TasksListPage = ({ taskType }) => {
   const isMounted = useIsMounted();
   const axiosInstance = useAxios();
   const handleFilters = (e) => {
-    setFilters({ ...filters, [e.target.name]: e.target.value });
+    const newFilterValues = { ...filters, [e.target.name]: e.target.value };
+    setFilters(newFilterValues);
+    if (e.target.name !== 'search') {
+      secureLocalStorage.updateStoredValue(`${taskType}-tasksSortBy`, newFilterValues.sortBy);
+      secureLocalStorage.updateStoredValue(`${taskType}-tasksGroupBy`, newFilterValues.groupBy);
+    }
   };
   const formatSortByValue = (sortValue) => {
     const [sortOrder, sortVariable] = sortValue.split('-');
@@ -186,7 +192,12 @@ const TasksListPage = ({ taskType }) => {
         </div>
       </div>
       <div>
-        <TaskFilters search={filters.search} handleFilters={handleFilters} />
+        <TaskFilters
+          search={filters.search}
+          sortBy={filters.sortBy}
+          groupBy={filters.groupBy}
+          handleFilters={handleFilters}
+        />
       </div>
       <div className="govuk-grid-row">
         <div className="govuk-grid-column-full">

--- a/client/src/pages/tasks/components/TaskFilters.jsx
+++ b/client/src/pages/tasks/components/TaskFilters.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-const TaskFilters = ({ search, handleFilters }) => {
+const TaskFilters = ({ search, sortBy, groupBy, handleFilters }) => {
   return (
     <div className="govuk-grid-row">
       <div className="govuk-grid-column-one-third">
@@ -9,13 +9,19 @@ const TaskFilters = ({ search, handleFilters }) => {
           <label className="govuk-label" htmlFor="sort">
             Sort by:
           </label>
-          <select className="govuk-select" id="sort" name="sortBy" onChange={handleFilters}>
+          <select
+            className="govuk-select"
+            id="sort"
+            name="sortBy"
+            onChange={handleFilters}
+            value={sortBy}
+          >
             <option value="asc-dueDate">Oldest due date</option>
             <option value="desc-dueDate">Latest due date</option>
             <option value="asc-created">Oldest created date</option>
             <option value="desc-created">Latest created date</option>
-            <option value="asc-priority">Highest priority</option>
-            <option value="desc-priority">Lowest priority</option>
+            <option value="desc-priority">Highest priority</option>
+            <option value="asc-priority">Lowest priority</option>
           </select>
         </div>
       </div>
@@ -24,7 +30,13 @@ const TaskFilters = ({ search, handleFilters }) => {
           <label className="govuk-label" htmlFor="group">
             Group by:
           </label>
-          <select className="govuk-select" id="group" name="groupBy" onChange={handleFilters}>
+          <select
+            className="govuk-select"
+            id="group"
+            name="groupBy"
+            onChange={handleFilters}
+            value={groupBy}
+          >
             <option value="category">Category</option>
             <option value="businessKey">BF Reference</option>
             <option value="priority">Priority</option>
@@ -58,6 +70,8 @@ TaskFilters.defaultProps = {
 TaskFilters.propTypes = {
   handleFilters: PropTypes.func.isRequired,
   search: PropTypes.string,
+  sortBy: PropTypes.string.isRequired,
+  groupBy: PropTypes.string.isRequired,
 };
 
 export default TaskFilters;

--- a/client/src/pages/tasks/components/TaskFilters.test.jsx
+++ b/client/src/pages/tasks/components/TaskFilters.test.jsx
@@ -10,11 +10,15 @@ describe('TaskFilters', () => {
   });
 
   it('renders without crashing', () => {
-    shallow(<TaskFilters search="" handleFilters={mockHandleFilter} />);
+    shallow(
+      <TaskFilters search="" sortBy="test" groupBy="test" handleFilters={mockHandleFilter} />
+    );
   });
 
   it('calls handleFilter when sortBy option has been chosen', () => {
-    const wrapper = shallow(<TaskFilters search="" handleFilters={mockHandleFilter} />);
+    const wrapper = shallow(
+      <TaskFilters search="" sortBy="test" groupBy="test" handleFilters={mockHandleFilter} />
+    );
     const sortBy = wrapper.find('select[id="sort"]').at(0);
 
     sortBy.simulate('change', { event: { target: { value: 'desc-dueDate' } } });
@@ -23,7 +27,9 @@ describe('TaskFilters', () => {
   });
 
   it('calls handleFilter when groupBy option has been chosen', () => {
-    const wrapper = shallow(<TaskFilters search="" handleFilters={mockHandleFilter} />);
+    const wrapper = shallow(
+      <TaskFilters search="" sortBy="test" groupBy="test" handleFilters={mockHandleFilter} />
+    );
     const groupBy = wrapper.find('select[id="group"]').at(0);
 
     groupBy.simulate('change', { event: { target: { value: 'priority' } } });
@@ -32,7 +38,9 @@ describe('TaskFilters', () => {
   });
 
   it('calls handleFilter when search bar has input', () => {
-    const wrapper = shallow(<TaskFilters search="" handleFilters={mockHandleFilter} />);
+    const wrapper = shallow(
+      <TaskFilters search="" sortBy="test" groupBy="test" handleFilters={mockHandleFilter} />
+    );
     const searchBar = wrapper.find('input[id="filterTaskName"]').at(0);
 
     searchBar.simulate('change', { event: { target: { value: 'Border' } } });

--- a/client/src/utils/SecureLocalStorage.js
+++ b/client/src/utils/SecureLocalStorage.js
@@ -1,0 +1,9 @@
+import SecureLS from 'secure-ls';
+
+const secureLocalStorage = new SecureLS({
+  encodingType: 'aes',
+  encryptionSecret: process.env.WWW_STORAGE_KEY,
+  isCompression: true,
+});
+
+export default secureLocalStorage;

--- a/client/src/utils/SecureLocalStorage.js
+++ b/client/src/utils/SecureLocalStorage.js
@@ -6,4 +6,13 @@ const secureLocalStorage = new SecureLS({
   isCompression: true,
 });
 
+secureLocalStorage.setInitialValue = (key, defaultValue) => {
+  return secureLocalStorage.get(key) ? secureLocalStorage.get(key) : defaultValue;
+};
+
+secureLocalStorage.updateStoredValue = (key, updatedValue) => {
+  secureLocalStorage.remove(key);
+  secureLocalStorage.set(key, updatedValue);
+};
+
 export default secureLocalStorage;


### PR DESCRIPTION
### AC
The user should be able to alter task filters options and persist upon refreshing the page

### Updated
- Add the `secure-ls` package as used in COPv1 UI for local storage
- Added methods to the `SecureLs` class to keep component code concise
- If `TaskListPage` filters have already been set in local storage, those values are used else use the default value specified
- Passed all filter values to `TaskFilter` component in order to correct update the rendered filter selections
- Refactor `TaskListPage` test

### Notes
- The task filter persistence for group and your tasks are independent of each other

### To test
- Pull and run cop locally
- Login
- Navigate to `/tasks`
- *You should see the task filters set to their defaults 'Oldest due date' and 'Category'*
- Change these filters to other options i.e. 'Highest priority' and 'Assignee'
- *You should see the task list update with the corresponding filter selections*
- Navigate away from the page and navigate back to `/tasks` (or refresh page)
- *You should see most recent filter options selected being the rendered - the task list rendered should also correspond*
- Navigate to /tasks/your-tasks
- *You should see the task filters set to their defaults 'Oldest due date' and 'Category'*
- Change these filters to other options different to those chosen in /tasks i.e. 'Lowest priority' and 'BF reference'
- *You should see the task list update with the corresponding filter selections*
- Navigate away from the page and navigate back to `/tasks/your-tasks` (or refresh page)
- *You should see most recent filter options selected being the rendered - the task list rendered should also correspond*
- Navigate to /tasks
- *The selections made on /tasks/your-tasks should not be the same as /tasks*
