### PR TITLE
COP-2822 Follow on task forms

### DIFF
--- a/client/src/pages/tasks/TaskPage.jsx
+++ b/client/src/pages/tasks/TaskPage.jsx
@@ -19,13 +19,20 @@ const TaskPage = ({ taskId }) => {
   const navigation = useNavigation();
   const [keycloak] = useKeycloak();
   const [submitting, setSubmitting] = useState(false);
-
   const { submitForm } = apiHooks();
   const [task, setTask] = useState({
     isLoading: true,
     data: null,
   });
+
   useEffect(() => {
+    // Clear values so that when task page is reloaded with 'next task' it starts fresh
+    setSubmitting(false);
+    setTask({
+      isLoading: true,
+      data: null,
+    });
+
     const source = axios.CancelToken.source();
     const loadTask = async () => {
       if (axiosInstance) {

--- a/client/src/pages/tasks/TaskPage.test.jsx
+++ b/client/src/pages/tasks/TaskPage.test.jsx
@@ -187,7 +187,6 @@ describe('TaskPage', () => {
     expect(wrapper.find(ApplicationSpinner).exists()).toBe(false);
 
     const displayForm = wrapper.find(DisplayForm).at(0);
-
     expect(displayForm.exists()).toBe(true);
 
     await act(async () => {
@@ -198,15 +197,14 @@ describe('TaskPage', () => {
       });
       await wrapper.update();
     });
-
-    expect(mockNavigate).toBeCalledWith('/');
+    expect(wrapper.find(ApplicationSpinner).exists()).toBe(true);
 
     await act(async () => {
       await displayForm.props().handleOnCancel();
       await wrapper.update();
     });
 
-    expect(mockNavigate).toBeCalledWith('/');
+    expect(mockNavigate).toBeCalledWith('/tasks');
   });
 
   it('adds complete button if form is not present', async () => {
@@ -257,12 +255,5 @@ describe('TaskPage', () => {
     const completeButton = wrapper.find('button').at(0);
 
     expect(completeButton.exists()).toBe(true);
-
-    await act(async () => {
-      await completeButton.simulate('click');
-      await wrapper.update();
-    });
-
-    expect(mockNavigate).toBeCalledWith('/');
   });
 });

--- a/client/src/pages/tasks/hooks.js
+++ b/client/src/pages/tasks/hooks.js
@@ -14,7 +14,7 @@ export default () => {
   const currentUser = keycloak.tokenParsed.email;
 
   const submitForm = useCallback(
-    (submission, form, taskId, businessKey, handleOnFailure) => {
+    ({ submission, form, taskId, businessKey, handleOnFailure }) => {
       if (form) {
         const variables = {
           [form.name]: {

--- a/client/src/pages/tasks/hooks.js
+++ b/client/src/pages/tasks/hooks.js
@@ -14,7 +14,7 @@ export default () => {
   const currentUser = keycloak.tokenParsed.email;
 
   const submitForm = useCallback(
-    ({ submission, form, taskId, businessKey, handleOnFailure }) => {
+    (submission, form, taskId, businessKey, handleOnFailure) => {
       if (form) {
         const variables = {
           [form.name]: {
@@ -54,7 +54,7 @@ export default () => {
           });
       }
     },
-    [axiosInstance, navigation, setAlertContext, t]
+    [axiosInstance, navigation, setAlertContext, t, currentUser]
   );
 
   return {


### PR DESCRIPTION
### AC
If there is a follow-on form from a task, and this form is assigned to the current user, it should display

### Updated
- added follow on form logic to task submit hook
- updated tests for task submit hook
- reviewed why tests were failing for TaskPage:
- - removed the navigation assertion as the navigation now happens in the submit and not from the TaskPage
- - removed click continue button test, discussing with Tom C the expected behaviour and will then implement that


### To Test
_Scenario One: starting with a new form_
- fill out a collect-event-at-border form with seized items, cash, and firearms
- click 'submit'
> you should see the next form load (this is triggered by the form submit hook)
- complete that form
- click submit
> you should see the next form load (this is triggered by the task submit hook)

-Scenario Two: follow on form started from task_
- fill out a collect-event-at-border form (with any detection)
- click submit
- DO NOT submit the next form, instead go to your tasks
- click on your event-at-border next task
- complete that form
- click submit
> you should see the next form load (this is triggered by the task submit hook)
- complete all forms
> you should be returned to tasks with confirmation message

_Scenario Three: no follow on forms from the task_
- submit an intelligence referral form
- go to your group tasks
- click 'claim' against the enhance task
- fill out the enhance task
- click submit
> you should be returned to tasks with a completed message