### PR TITLE
COP-2822 Showing/Hiding form based on assignee

### DIFF
--- a/client/src/pages/tasks/TaskPage.jsx
+++ b/client/src/pages/tasks/TaskPage.jsx
@@ -232,27 +232,6 @@ const TaskPage = ({ taskId }) => {
               </div>
             </div>
           </div>
-          <div className="govuk-grid-row">
-            <div className="govuk-grid-column-full">
-              <button
-                className="govuk-button"
-                type="button"
-                onClick={() => {
-                  submitForm({
-                    submission: {},
-                    form: {
-                      name: 'no-form',
-                    },
-                    taskId,
-                    businessKey: processInstance.businessKey,
-                    handleOnFailure,
-                  });
-                }}
-              >
-                {t('pages.task.actions.complete')}
-              </button>
-            </div>
-          </div>
         </>
       )}
     </>

--- a/client/src/pages/tasks/TaskPage.jsx
+++ b/client/src/pages/tasks/TaskPage.jsx
@@ -27,9 +27,14 @@ const TaskPage = ({ taskId }) => {
   });
 
   useEffect(() => {
-    // Reset state
+    // Reset state so that when task page is reloaded with 'next task' it starts fresh
     const source = axios.CancelToken.source();
     setTask({ isLoading: true, data: null });
+    setSubmitting(false);
+    setTask({
+      isLoading: true,
+      data: null,
+    });
 
     // Get task data
     const loadTask = async () => {

--- a/client/src/pages/tasks/TaskPage.jsx
+++ b/client/src/pages/tasks/TaskPage.jsx
@@ -32,10 +32,6 @@ const TaskPage = ({ taskId }) => {
     const source = axios.CancelToken.source();
     setTask({ isLoading: true, data: null });
     setSubmitting(false);
-    setTask({
-      isLoading: true,
-      data: null,
-    });
 
     // Get task data
     const loadTask = async () => {

--- a/client/src/pages/tasks/TaskPage.jsx
+++ b/client/src/pages/tasks/TaskPage.jsx
@@ -19,8 +19,9 @@ const TaskPage = ({ taskId }) => {
   const navigation = useNavigation();
   const [keycloak] = useKeycloak();
   const currentUser = keycloak.tokenParsed.email;
-  const [submitting, setSubmitting] = useState(false);
   const { submitForm } = apiHooks();
+  const [submitting, setSubmitting] = useState(false);
+  const [assigneeText, setAssigneeText] = useState();
   const [task, setTask] = useState({
     isLoading: true,
     data: null,
@@ -96,6 +97,7 @@ const TaskPage = ({ taskId }) => {
                 task: taskInfo,
               },
             });
+            setAssigneeText(t('pages.task.current-assignee'));
           } else {
             setTask({
               isLoading: false,
@@ -108,6 +110,11 @@ const TaskPage = ({ taskId }) => {
                 task: taskInfo,
               },
             });
+            if (!taskData.data.task.assignee) {
+              setAssigneeText(t('pages.task.unassigned'));
+            } else {
+              setAssigneeText(taskData.data.task.assignee);
+            }
           }
         } catch (e) {
           setTask({ isLoading: true, data: null });
@@ -126,16 +133,6 @@ const TaskPage = ({ taskId }) => {
 
   if (!task.data) {
     return null;
-  }
-  const { tokenParsed } = keycloak;
-
-  let assignee = t('pages.task.current-assignee');
-  const taskAssignee = task.data.task.assignee;
-
-  if (!taskAssignee) {
-    assignee = t('pages.task.unassigned');
-  } else if (taskAssignee && taskAssignee !== tokenParsed.email) {
-    assignee = tokenParsed.email;
   }
 
   const {
@@ -178,7 +175,7 @@ const TaskPage = ({ taskId }) => {
         </div>
         <div className="govuk-grid-column-one-quarter" id="taskAssignee">
           <span className="govuk-caption-m govuk-!-font-size-19">{t('pages.task.assignee')}</span>
-          <h4 className="govuk-heading-m govuk-!-font-size-19">{assignee}</h4>
+          <h4 className="govuk-heading-m govuk-!-font-size-19">{assigneeText}</h4>
         </div>
       </div>
       <div className="govuk-grid-row">

--- a/client/src/pages/tasks/TaskPage.test.jsx
+++ b/client/src/pages/tasks/TaskPage.test.jsx
@@ -137,7 +137,69 @@ describe('TaskPage', () => {
     expect(taskDue.find('h4').at(0).text()).not.toBe('');
   });
 
-  it('can submit task', async () => {
+  it('displays the form when task assignee is equal to current user', async () => {
+    mockAxios.onGet('/ui/tasks/taskId').reply(200, {
+      form: {
+        name: 'testForm',
+        display: 'form',
+        components: [],
+      },
+      task: {
+        id: 'taskId',
+        assignee: 'test', // this is declared in setupTests.js
+        name: 'task name',
+        due: moment(),
+        priority: '1000',
+        variables: {
+          taskVariableA: {
+            type: 'Json',
+            value: JSON.stringify({ data: { text: 'test' } }),
+          },
+          testEmail: {
+            value: 'test',
+            type: 'string',
+          },
+        },
+      },
+      variables: {
+        email: {
+          value: 'test',
+          type: 'string',
+        },
+        test: {
+          type: 'Json',
+          value: JSON.stringify({ data: { text: 'test' } }),
+        },
+        'testForm::submissionData': {
+          type: 'Json',
+          value: JSON.stringify({ data: { text: 'test' } }),
+        },
+      },
+      processDefinition: {
+        category: 'test',
+      },
+      processInstance: {
+        businessKey: 'BUSINESS KEY',
+      },
+    });
+
+    const wrapper = await mount(
+      <AlertContextProvider>
+        <TaskPage taskId="taskId" />
+      </AlertContextProvider>
+    );
+
+    await act(async () => {
+      await Promise.resolve(wrapper);
+      await new Promise((resolve) => setImmediate(resolve));
+      await wrapper.update();
+    });
+
+    expect(wrapper.find(ApplicationSpinner).exists()).toBe(false);
+    expect(wrapper.find(DisplayForm).exists()).toBe(true);
+  });
+
+  it('does not display the form when task assignee is not equal to current user', async () => {
     mockAxios.onGet('/ui/tasks/taskId').reply(200, {
       form: {
         name: 'testForm',
@@ -149,7 +211,68 @@ describe('TaskPage', () => {
         name: 'task name',
         due: moment(),
         priority: '1000',
-        assignee: 'apples',
+        assignee: 'not-test',
+        variables: {
+          taskVariableA: {
+            type: 'Json',
+            value: JSON.stringify({ data: { text: 'test' } }),
+          },
+          testEmail: {
+            value: 'test',
+            type: 'string',
+          },
+        },
+      },
+      variables: {
+        email: {
+          value: 'test',
+          type: 'string',
+        },
+        test: {
+          type: 'Json',
+          value: JSON.stringify({ data: { text: 'test' } }),
+        },
+        'testForm::submissionData': {
+          type: 'Json',
+          value: JSON.stringify({ data: { text: 'test' } }),
+        },
+      },
+      processDefinition: {
+        category: 'test',
+      },
+      processInstance: {
+        businessKey: 'BUSINESS KEY',
+      },
+    });
+    const wrapper = await mount(
+      <AlertContextProvider>
+        <TaskPage taskId="taskId" />
+      </AlertContextProvider>
+    );
+
+    await act(async () => {
+      await Promise.resolve(wrapper);
+      await new Promise((resolve) => setImmediate(resolve));
+      await wrapper.update();
+    });
+
+    expect(wrapper.find(ApplicationSpinner).exists()).toBe(false);
+    expect(wrapper.find(DisplayForm).exists()).toBe(false);
+  });
+
+  it('can submit task', async () => {
+    mockAxios.onGet('/ui/tasks/taskId').reply(200, {
+      form: {
+        name: 'testForm',
+        display: 'form',
+        components: [],
+      },
+      task: {
+        id: 'taskId',
+        assignee: 'test',
+        name: 'task name',
+        due: moment(),
+        priority: '1000',
       },
       variables: {
         email: 'test',
@@ -205,55 +328,5 @@ describe('TaskPage', () => {
     });
 
     expect(mockNavigate).toBeCalledWith('/tasks');
-  });
-
-  it('adds complete button if form is not present', async () => {
-    mockAxios.onGet('/ui/tasks/taskId').reply(200, {
-      form: null,
-      task: {
-        id: 'taskId',
-        name: 'task name',
-        due: moment(),
-        priority: '1000',
-        assignee: 'apples',
-      },
-      variables: {
-        email: 'test',
-        test: {
-          type: 'Json',
-          value: JSON.stringify({ data: { text: 'test' } }),
-        },
-        submissionData: {
-          type: 'Json',
-          value: JSON.stringify({ data: { text: 'test' } }),
-        },
-      },
-      processDefinition: {
-        category: 'test',
-      },
-      processInstance: {
-        businessKey: 'BUSINESS KEY',
-      },
-    });
-
-    mockAxios.onPost('/camunda/engine-rest/task/taskId/submit-form').reply(200, {});
-
-    const wrapper = await mount(
-      <AlertContextProvider>
-        <TaskPage taskId="taskId" />
-      </AlertContextProvider>
-    );
-
-    await act(async () => {
-      await Promise.resolve(wrapper);
-      await new Promise((resolve) => setImmediate(resolve));
-      await wrapper.update();
-    });
-
-    expect(wrapper.find(ApplicationSpinner).exists()).toBe(false);
-
-    const completeButton = wrapper.find('button').at(0);
-
-    expect(completeButton.exists()).toBe(true);
   });
 });

--- a/client/src/pages/tasks/components/TaskList.jsx
+++ b/client/src/pages/tasks/components/TaskList.jsx
@@ -30,7 +30,7 @@ const TaskList = ({ tasks, groupBy }) => {
                   }}
                 />
                 <h2 className="app-task-list__section">{`${isPriority(key)} ${numberOfTasks} ${
-                  numberOfTasks < 2 ? 'task' : 'tasks'
+                  numberOfTasks === 1 ? 'task' : 'tasks'
                 }`}</h2>
                 {tasksGroupedBy[key].map((task) => (
                   <TaskListItem


### PR DESCRIPTION
## AC
If the task assignee and current user are the same, then show the form.
If there is no task assignee, do not show the form.
If there task assignee and current user are NOT the same, do not show the form.

## Notes
- agreed with Tom C that we should remove the 'complete' button as if you can't see the form you should not be completing the task

## Updated
- added check for assignee === current user
- updated state resets
- moved assignee into state
- removed complete button

## To test
- create a task via postman assigned to jennifer.wallace@digital.homeoffice.gov.uk
- create a few more tasks assigned to you or null
- go to your group tasks
- click on the task assigned to Jennifer
>- you should not see a form
- go back
- click on a task assigned to you
>- you should see a form
- go back
- click on a task that is unclaimed
>- you should not see a form
- go back
- claim the task that was assigned to Jennifer
>- you should see a form
- go back
- claim the task that was unclaimed
>- you should see a form