### PR TITLE
COP-4210 Set task page to auto-refresh the task list every 5min

### DIFF
--- a/client/public/locales/en-GB/translation.json
+++ b/client/public/locales/en-GB/translation.json
@@ -185,7 +185,8 @@
         "heading": "{{count}} tasks assigned to your team",
         "status": "Open",
         "title": "Your team's tasks | Central Operations Platform"
-      }
+      },
+      "refresh": "This page auto refreshes every 5 minutes"
     }
   }
 }

--- a/client/src/pages/tasks/TasksListPage.jsx
+++ b/client/src/pages/tasks/TasksListPage.jsx
@@ -144,12 +144,12 @@ const TasksListPage = ({ taskType }) => {
                   }
                 });
               }
-
               setData({
                 isLoading: false,
                 tasks: tasksResponse.data,
               });
               setTaskCount(taskCountResponse.data.count);
+              setTimeout(loadTasks, 300000);
             }
           }
         } catch (e) {
@@ -163,6 +163,7 @@ const TasksListPage = ({ taskType }) => {
     loadTasks().then(() => {});
     return () => {
       source.cancel('Cancelling request');
+      clearTimeout(loadTasks);
     };
   }, [
     setData,
@@ -189,6 +190,9 @@ const TasksListPage = ({ taskType }) => {
           <h1 className="govuk-heading-l">
             {t(`pages.tasks.${taskType}.heading`, { count: taskCount })}
           </h1>
+          <div className="govuk-inset-text">
+            <strong>{t('pages.tasks.refresh')}</strong>
+          </div>
         </div>
       </div>
       <div>


### PR DESCRIPTION
## AC
Task pages should update their task list every 5 minutes

## Updated
- added a 5min setTimeout to loadTasks
- added content to say list will update every 5 min

## To Test
- go to your tasks
- leave page open
- submit a collect event at border task through Postman
- wait 5min
>- you should now see the next EaB task for the businessKey you submitted via postman in the your tasks list (without having refreshed the page yourself)
- go to group tasks
- leave page open
- submit an intel referral task through Postman
- wait 5 min
>- you should now see the an enhance task for the businessKey you submitted via postman in the group task list (without having refreshed the page yourself)