### PR TITLE
COP-3595 Mobile menu not showing

### DIFF
--- a/client/src/components/header/index.jsx
+++ b/client/src/components/header/index.jsx
@@ -102,6 +102,30 @@ const Header = () => {
           </div>
         </div>
       </header>
+      <div className="govuk-phase-banner govuk-width-container">
+        <p className="govuk-phase-banner__content">
+          <strong className="govuk-tag govuk-phase-banner__content__tag ">
+            {config.get('uiVersion')}
+          </strong>
+          <span>
+            <strong className="govuk-tag govuk-phase-banner__content__tag ">
+              {config.get('uiEnvironment')}
+            </strong>
+          </span>
+          <span className="govuk-phase-banner__text">
+            {t('header.new-service-1')}{' '}
+            <a
+              className="govuk-link"
+              href={`${config.get('serviceDeskUrl')}/create/54`}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              {t('header.new-service-2')}
+            </a>{' '}
+            {t('header.new-service-3')}
+          </span>
+        </p>
+      </div>
     </>
   );
 };

--- a/client/src/components/header/index.jsx
+++ b/client/src/components/header/index.jsx
@@ -20,20 +20,20 @@ const Header = () => {
       <header className="govuk-header" role="banner" data-module="govuk-header">
         <SkipLink />
         <div className="govuk-header__container govuk-width-container">
-          <div className="govuk-grid-row">
-            <div className="govuk-grid-column-one-half">
-              <a
-                href="/"
-                id="home"
-                onClick={async (e) => {
-                  e.preventDefault();
-                  await navigation.navigate('/');
-                }}
-                className="govuk-header__link govuk-header__link--service-name"
-              >
-                {t('header.service-name')}
-              </a>
-            </div>
+          <div className="govuk-header__logo">
+            <a
+              href="/"
+              id="home"
+              onClick={async (e) => {
+                e.preventDefault();
+                await navigation.navigate('/');
+              }}
+              className="govuk-header__link govuk-header__link--service-name"
+            >
+              {t('header.service-name')}
+            </a>
+          </div>
+          <div className="govuk-header__content">
             <button
               type="button"
               className={
@@ -49,7 +49,7 @@ const Header = () => {
             >
               Menu
             </button>
-            <nav className="govuk-grid-column-one-half">
+            <nav id="globalNav">
               <ul
                 id="navigation"
                 className={
@@ -101,30 +101,6 @@ const Header = () => {
           </div>
         </div>
       </header>
-      <div className="govuk-phase-banner govuk-width-container">
-        <p className="govuk-phase-banner__content">
-          <strong className="govuk-tag govuk-phase-banner__content__tag ">
-            {config.get('uiVersion')}
-          </strong>
-          <span>
-            <strong className="govuk-tag govuk-phase-banner__content__tag ">
-              {config.get('uiEnvironment')}
-            </strong>
-          </span>
-          <span className="govuk-phase-banner__text">
-            {t('header.new-service-1')}{' '}
-            <a
-              className="govuk-link"
-              href={`${config.get('serviceDeskUrl')}/create/54`}
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              {t('header.new-service-2')}
-            </a>{' '}
-            {t('header.new-service-3')}
-          </span>
-        </p>
-      </div>
     </>
   );
 };

--- a/client/src/components/header/index.jsx
+++ b/client/src/components/header/index.jsx
@@ -66,6 +66,7 @@ const Header = () => {
                     className="govuk-header__link"
                     onClick={async (e) => {
                       e.preventDefault();
+                      toggleMenu(e);
                       await navigation.navigate('/forms/edit-your-profile');
                     }}
                   >

--- a/client/src/components/header/index.jsx
+++ b/client/src/components/header/index.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigation } from 'react-navi';
 import config from 'react-global-configuration';
@@ -8,6 +8,12 @@ import './index.scss';
 const Header = () => {
   const { t } = useTranslation();
   const navigation = useNavigation();
+  const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
+
+  const toggleMenu = (e) => {
+    e.preventDefault();
+    setMobileMenuOpen(!mobileMenuOpen);
+  };
 
   return (
     <>
@@ -30,16 +36,27 @@ const Header = () => {
             </div>
             <button
               type="button"
-              className="govuk-header__menu-button govuk-js-header-toggle"
+              className={
+                mobileMenuOpen
+                  ? 'govuk-header__menu-button govuk-js-header-toggle govuk-header__menu-button--open'
+                  : 'govuk-header__menu-button govuk-js-header-toggle'
+              }
               aria-controls="navigation"
               aria-label="Show or hide navigation menu"
+              onClick={(e) => {
+                toggleMenu(e);
+              }}
             >
               Menu
             </button>
             <nav className="govuk-grid-column-one-half">
               <ul
                 id="navigation"
-                className="govuk-header__navigation "
+                className={
+                  mobileMenuOpen
+                    ? 'govuk-header__navigation govuk-header__navigation--open'
+                    : 'govuk-header__navigation'
+                }
                 aria-label="Navigation menu"
               >
                 <li className="govuk-header__navigation-item">

--- a/client/src/components/header/index.scss
+++ b/client/src/components/header/index.scss
@@ -1,3 +1,5 @@
-#navigation {
-  text-align: right;
+@media (min-width: 48.0625em) {
+  #globalNav {
+    text-align: right;
+  }
 }


### PR DESCRIPTION
## AC
Mobile menu should appear, and currently is not

## Updated
- updated structure to follow GDS guide for nav
- put service name in the logo space as COP does not use a logo, but just keeps service name on the left
- added toggle functions for nav

## To test
- open cop-ui in a mobile view
- tap on 'menu'
>- you should see the menu items
- tap on 'profile menu item'
> menu should close and take you to profile page
- try tapping menu on various pages
> menu should open/close on tap
