### PR TITLE
Update govuk-frontend to latest version

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -9594,9 +9594,9 @@
       "integrity": "sha512-EcwnP9PsWubmTcsJtLF8w0D5b69j43LwYtSqGyPtO3903J0bbwB2t5ujWZ9UhsbLamuUmigBkNpLItU3/KuFqw=="
     },
     "govuk-frontend": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-3.7.0.tgz",
-      "integrity": "sha512-G3bqoKGGF8YQ18UJH9tTARrwB8i7iPwN1xc8RXwWyx91q0p/Xl10uNywZLkzGWcJDzEz1vwmBTTL3SLDU/KxNg=="
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-3.10.1.tgz",
+      "integrity": "sha512-2x6B0jV1pTx4Alxm3MY222BfIQpg+ctUYaUzyBjmNkisWKdRmCP61oyFXklZgqXMjvaN+oo3rRbAALrxFTeeig=="
     },
     "graceful-fs": {
       "version": "4.2.4",

--- a/client/package.json
+++ b/client/package.json
@@ -10,7 +10,7 @@
     "axios": "^0.19.2",
     "dayjs": "^1.9.6",
     "govuk-colours": "^1.1.0",
-    "govuk-frontend": "^3.6.0",
+    "govuk-frontend": "^3.10.1",
     "html-react-parser": "^0.10.5",
     "i18next": "^19.4.4",
     "i18next-browser-languagedetector": "^4.1.1",


### PR DESCRIPTION
This fixes [an issue](https://github.com/alphagov/govuk-frontend/pull/1879) with the `skip-link` component.