### PR TITLE
Temporarily add alternative form route

### DIFF
--- a/client/src/routes/index.js
+++ b/client/src/routes/index.js
@@ -26,6 +26,7 @@ const routes = mount({
     })
   ),
   '/forms': lazy(() => import('../pages/forms/routes')),
+  '/submit-a-form': lazy(() => import('../pages/forms/routes')),
   '/reports': lazy(() => import('../pages/reports/routes')),
   '/tasks': lazy(() => import('../pages/tasks/routes')),
   '/cases': lazy(() => import('../pages/cases/routes')),

--- a/client/src/routes/route.test.js
+++ b/client/src/routes/route.test.js
@@ -12,6 +12,7 @@ describe('Base routes', () => {
     ${'/tasks'}                     | ${true}
     ${'/cases'}                     | ${true}
     ${'/forms'}                     | ${true}
+    ${'/submit-a-form'}             | ${true}
     ${'/tasks/id'}                  | ${true}
     ${'/forms/id'}                  | ${true}
     ${'/login'}                     | ${true}


### PR DESCRIPTION
This is being added so we don't need to edit forms that are shared by both UIs but which link to other forms. I'll add a ticket for us to remove this route and update forms once we've migrated.