### PR TITLE
COP-4454 Move interpolateContext prop into contexts object

### DIFF
--- a/client/src/components/form/DisplayForm.jsx
+++ b/client/src/components/form/DisplayForm.jsx
@@ -130,6 +130,7 @@ const DisplayForm = ({
         surname: familyName,
         teamid,
       },
+      ...interpolateContext,
     },
   };
   const [augmentedSubmission] = useState(_.merge(existingSubmission, contexts));
@@ -200,8 +201,8 @@ const DisplayForm = ({
       groups: keycloak.tokenParsed.groups,
     },
     ...contexts.data,
-    ...interpolateContext,
   });
+
   return (
     <Loader
       show={submitting}


### PR DESCRIPTION
A number of forms and processes refer to the `processContext` property however this has not been implemented in cop-ui such that it is passed to forms and bpmns correctly. The PR adds `processContext` to the `contexts` object which is then passed down to forms

### To test
- Pull and run cop locally
- Login
- Submit intel referral form
- Claim the raised task
- *You should see the date time pre-populated*
- Fill out the rest of the enhance intel form
- *You should be able to submit the form successfully*
- *There should be no incidents raised in cockpit*