### PR TITLE
COP-4280 Update to use ErrorAlert directly and not through AlertContext/Banner

### DIFF
--- a/client/src/components/form/DisplayForm.test.jsx
+++ b/client/src/components/form/DisplayForm.test.jsx
@@ -1,12 +1,11 @@
 import React from 'react';
 import { mount } from 'enzyme';
-import { act } from '@testing-library/react';
 import { Form } from 'react-formio';
+import { act } from '@testing-library/react';
+import FormErrorsAlert from '../alert/FormErrorsAlert';
 import DisplayForm from './DisplayForm';
-import { AlertContextProvider } from '../../utils/AlertContext';
-import AlertBanner from '../alert/AlertBanner';
 
-describe('Display form', () => {
+describe('FormPage', () => {
   beforeEach(() => {
     // eslint-disable-next-line no-console
     console.error = jest.fn();
@@ -14,105 +13,113 @@ describe('Display form', () => {
     console.warn = jest.fn();
   });
 
+  const formDetails = {
+    formName: 'test',
+    formDisplay: 'form',
+    formId: 'id',
+    formVersionId: 'version',
+    formTitle: 'title',
+    componentArray: [
+      {
+        id: 'eoduazt',
+        key: 'textField1',
+        case: '',
+        mask: false,
+        tags: '',
+        type: 'textfield',
+        input: true,
+        label: 'Text Field',
+        logic: [],
+        hidden: false,
+        prefix: '',
+        suffix: '',
+        unique: false,
+        validate: {
+          json: '',
+          custom: '',
+          unique: false,
+          pattern: '',
+          multiple: false,
+          required: true,
+          maxLength: '',
+          minLength: '',
+          customMessage: '',
+          customPrivate: false,
+          strictDateValidation: false,
+        },
+        widget: {
+          type: 'input',
+        },
+      },
+      {
+        id: 'eoduazg',
+        key: 'textField2',
+        case: '',
+        mask: false,
+        tags: '',
+        type: 'textfield',
+        input: true,
+        label: 'Text Field',
+        logic: [],
+        hidden: false,
+        prefix: '',
+        suffix: '',
+        unique: false,
+        validate: {
+          json: '',
+          custom: '',
+          unique: false,
+          pattern: '',
+          multiple: false,
+          required: true,
+          maxLength: '',
+          minLength: '',
+          customMessage: '',
+          customPrivate: false,
+          strictDateValidation: false,
+        },
+        widget: {
+          type: 'input',
+        },
+      },
+      {
+        id: 'e23op57',
+        key: 'submit',
+        size: 'md',
+        type: 'button',
+        block: false,
+        input: true,
+        label: 'Submit',
+        theme: 'primary',
+        action: 'submit',
+        hidden: false,
+        prefix: '',
+        suffix: '',
+        unique: false,
+        widget: {
+          type: 'input',
+        },
+      },
+    ],
+  };
+  const errorDetails = [
+    {
+      component: {
+        id: 'id',
+        key: 'textField',
+      },
+      message: 'Textfield is required',
+    },
+  ];
+
   it('renders overlay when form is being submitted', async () => {
     const wrapper = await mount(
-      <AlertContextProvider>
-        <AlertBanner />
-        <DisplayForm
-          form={{
-            name: 'test',
-            display: 'form',
-            id: 'id',
-            versionId: 'version',
-            title: 'title',
-            components: [
-              {
-                id: 'eoduazt',
-                key: 'textField1',
-                case: '',
-                mask: false,
-                tags: '',
-                type: 'textfield',
-                input: true,
-                label: 'Text Field',
-                logic: [],
-                hidden: false,
-                prefix: '',
-                suffix: '',
-                unique: false,
-                validate: {
-                  json: '',
-                  custom: '',
-                  unique: false,
-                  pattern: '',
-                  multiple: false,
-                  required: true,
-                  maxLength: '',
-                  minLength: '',
-                  customMessage: '',
-                  customPrivate: false,
-                  strictDateValidation: false,
-                },
-                widget: {
-                  type: 'input',
-                },
-              },
-              {
-                id: 'eoduazg',
-                key: 'textField2',
-                case: '',
-                mask: false,
-                tags: '',
-                type: 'textfield',
-                input: true,
-                label: 'Text Field',
-                logic: [],
-                hidden: false,
-                prefix: '',
-                suffix: '',
-                unique: false,
-                validate: {
-                  json: '',
-                  custom: '',
-                  unique: false,
-                  pattern: '',
-                  multiple: false,
-                  required: true,
-                  maxLength: '',
-                  minLength: '',
-                  customMessage: '',
-                  customPrivate: false,
-                  strictDateValidation: false,
-                },
-                widget: {
-                  type: 'input',
-                },
-              },
-              {
-                id: 'e23op57',
-                key: 'submit',
-                size: 'md',
-                type: 'button',
-                block: false,
-                input: true,
-                label: 'Submit',
-                theme: 'primary',
-                action: 'submit',
-                hidden: false,
-                prefix: '',
-                suffix: '',
-                unique: false,
-                widget: {
-                  type: 'input',
-                },
-              },
-            ],
-          }}
-          submitting
-          handleOnCancel={jest.fn()}
-          handleOnSubmit={jest.fn()}
-        />
-      </AlertContextProvider>
+      <DisplayForm
+        form={formDetails}
+        submitting
+        handleOnCancel={jest.fn()}
+        handleOnSubmit={jest.fn()}
+      />
     );
 
     await act(async () => {
@@ -121,116 +128,86 @@ describe('Display form', () => {
       await wrapper.update();
     });
 
-    const loader = wrapper.find('.Loader').at(0);
-    expect(loader.exists()).toBe(true);
-    const loaderContext = wrapper.find('.Loader__content');
-    expect(loaderContext.prop('style')).toHaveProperty('opacity', 1);
+    expect(wrapper.find('.Loader').at(0).exists()).toBe(true);
+    expect(wrapper.find('.Loader__content').prop('style')).toHaveProperty('opacity', 1);
   });
 
   it('scrolls to the top on next', async () => {
     window.scrollTo = jest.fn();
     const wrapper = await mount(
       <DisplayForm
-        form={{
-          name: 'test',
-          display: 'form',
-          id: 'id',
-          versionId: 'version',
-          title: 'title',
-          components: [
-            {
-              id: 'eoduazt',
-              key: 'textField1',
-              case: '',
-              mask: false,
-              tags: '',
-              type: 'textfield',
-              input: true,
-              label: 'Text Field',
-              logic: [],
-              hidden: false,
-              prefix: '',
-              suffix: '',
-              unique: false,
-              validate: {
-                json: '',
-                custom: '',
-                unique: false,
-                pattern: '',
-                multiple: false,
-                required: true,
-                maxLength: '',
-                minLength: '',
-                customMessage: '',
-                customPrivate: false,
-                strictDateValidation: false,
-              },
-              widget: {
-                type: 'input',
-              },
-            },
-            {
-              id: 'eoduazg',
-              key: 'textField2',
-              case: '',
-              mask: false,
-              tags: '',
-              type: 'textfield',
-              input: true,
-              label: 'Text Field',
-              logic: [],
-              hidden: false,
-              prefix: '',
-              suffix: '',
-              unique: false,
-              validate: {
-                json: '',
-                custom: '',
-                unique: false,
-                pattern: '',
-                multiple: false,
-                required: true,
-                maxLength: '',
-                minLength: '',
-                customMessage: '',
-                customPrivate: false,
-                strictDateValidation: false,
-              },
-              widget: {
-                type: 'input',
-              },
-            },
-            {
-              id: 'e23op57',
-              key: 'submit',
-              size: 'md',
-              type: 'button',
-              block: false,
-              input: true,
-              label: 'Submit',
-              theme: 'primary',
-              action: 'submit',
-              hidden: false,
-              prefix: '',
-              suffix: '',
-              unique: false,
-              widget: {
-                type: 'input',
-              },
-            },
-          ],
-        }}
-        submitting={false}
+        form={formDetails}
+        submitting
         handleOnCancel={jest.fn()}
         handleOnSubmit={jest.fn()}
       />
     );
 
     const form = wrapper.find(Form).at(0);
+
     form.props().onNextPage();
     expect(window.scrollTo).toBeCalledWith(0, 0);
 
     form.props().onPrevPage();
     expect(window.scrollTo).toBeCalledWith(0, 0);
+  });
+
+  it('renders error on form', async () => {
+    const wrapper = await mount(
+      <DisplayForm
+        form={formDetails}
+        submitting
+        handleOnCancel={jest.fn()}
+        handleOnSubmit={jest.fn()}
+      />
+    );
+
+    await act(async () => {
+      await Promise.resolve(wrapper);
+      await new Promise((resolve) => setImmediate(resolve));
+      await wrapper.update();
+    });
+
+    const form = wrapper.find(Form).at(0);
+    await form.instance().createPromise;
+
+    form.instance().props.onError(errorDetails);
+    await act(async () => {
+      await wrapper.update();
+    });
+
+    expect(wrapper.find(FormErrorsAlert).exists()).toBe(true);
+    expect(wrapper.find('.govuk-error-summary')).toHaveLength(1);
+  });
+
+  it('removes the error alert when you go to a previous page of the form', async () => {
+    const wrapper = await mount(
+      <DisplayForm
+        form={formDetails}
+        submitting
+        handleOnCancel={jest.fn()}
+        handleOnSubmit={jest.fn()}
+      />
+    );
+    await act(async () => {
+      await Promise.resolve(wrapper);
+      await new Promise((resolve) => setImmediate(resolve));
+      await wrapper.update();
+    });
+
+    const form = wrapper.find(Form).at(0);
+    await form.instance().createPromise;
+
+    form.instance().props.onError(errorDetails);
+    await act(async () => {
+      await wrapper.update();
+    });
+    expect(wrapper.find('.govuk-error-summary')).toHaveLength(1);
+
+    form.props().onPrevPage();
+    await act(async () => {
+      await wrapper.update();
+    });
+    expect(wrapper.find('.govuk-error-summary')).toHaveLength(0);
   });
 });


### PR DESCRIPTION
## AC
Form error alerts should not persist

## Updated
DisplayForm to use ErrorAlert rather than AlertBanner

## To test

### Scenario One: going back clears the error alert box
 * open collect-event-at-border form
 * click next
 * click next (without selecting any radio buttons)
 > you should see error alerts at the top of the page
 * click 'back'
 > you should no longer see the error alert box

### Scenario Two: going to a previous page of the form clears the error alert box
 * open collect-event-at-border form
 * click next
 * click next without selecting any radio buttons
 > you should see error alerts at the top of the page
 * select a radio button on the first question
 > you should no longer see the error alert for that question at the top of the page
 * select a radio button on the second question
 > you should no longer see the error alerts
 * click next
 * click next without answering any questions
 * > you should see an error alert at the top of the page
 * click previous (button at the bottom of the form)
 * > you should no longer see the error alert

### Scenario Three: submitting a form persists the alert box
 * open the covid-compliance-check form
 * complete the form (do not tick to submit another)
 * submit the form
 > you should be returned to the dashboard with a submit confirmation alert
 * go to another page
 > you should still see the submit confirmation alert
 * click on close confirmation button
 > you should no longer see the submit confirmation alert

### Scenario Four: API error
 * open the hot debrief form (as we know this is currently erroring on COPv2
 * fill out the mandatory questions
 * submit the form
 > you should see an Internal system error alert
 * go back
 > you should still see the internal system error alert
 * refresh the page
 * > you should no longer see the internal system error alert