### PR TITLE
COP-2824 Add change due date feature

### DIFF
--- a/client/public/locales/en-GB/translation.json
+++ b/client/public/locales/en-GB/translation.json
@@ -159,7 +159,10 @@
     },
     "task": {
       "submission": {
-        "success-message": "You have successfully completed the task"
+        "success-message": "You have successfully completed the task",
+        "error": {
+          "due-date-change": "Task due date must be a real date"
+        }
       },
       "actions": {
         "complete": "Complete"

--- a/client/src/pages/tasks/TaskPage.test.jsx
+++ b/client/src/pages/tasks/TaskPage.test.jsx
@@ -393,16 +393,15 @@ describe('TaskPage', () => {
     );
 
     await waitFor(() => {
-      expect(screen.queryByText('cancel')).not.toBeInTheDocument();
       expect(screen.queryByText('Change priority')).not.toBeInTheDocument();
-      expect(screen.queryByText('change')).toBeInTheDocument();
+      // There are 2 instances of change on first render, one for due date and one for priority
+      expect(screen.queryAllByText('change')[1]).toBeInTheDocument();
     });
 
-    fireEvent.click(screen.getAllByText('change')[0]);
+    fireEvent.click(screen.getAllByText('change')[1]);
 
     expect(screen.queryByText('cancel')).toBeInTheDocument();
     expect(screen.queryByText('Change priority')).toBeInTheDocument();
-    expect(screen.queryByText('change')).not.toBeInTheDocument();
 
     const dropDown = getById(container, 'change-priority');
 

--- a/client/src/pages/tasks/TaskPage.test.jsx
+++ b/client/src/pages/tasks/TaskPage.test.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { shallow, mount } from 'enzyme';
 import MockAdapter from 'axios-mock-adapter';
 import axios from 'axios';
-import moment from 'moment';
+import dayjs from 'dayjs';
 import { act, screen, render, waitFor, fireEvent, queryByAttribute } from '@testing-library/react';
 import TaskPage from './TaskPage';
 import ApplicationSpinner from '../../components/ApplicationSpinner';
@@ -33,7 +33,7 @@ describe('TaskPage', () => {
       task: {
         id: 'taskId',
         name: 'task name',
-        due: moment(),
+        due: dayjs(),
         priority: '1000',
         assignee: null,
       },
@@ -79,7 +79,7 @@ describe('TaskPage', () => {
       task: {
         id: 'taskId',
         name: 'task name',
-        due: moment(),
+        due: dayjs(),
         priority: '1000',
         assignee: 'test',
         variables: {
@@ -158,7 +158,7 @@ describe('TaskPage', () => {
         id: 'taskId',
         assignee: 'test', // this is declared in setupTests.js
         name: 'task name',
-        due: moment(),
+        due: dayjs(),
         priority: '1000',
         variables: {
           taskVariableA: {
@@ -227,7 +227,7 @@ describe('TaskPage', () => {
       task: {
         id: 'taskId',
         name: 'task name',
-        due: moment(),
+        due: dayjs(),
         priority: '1000',
         assignee: 'not-test',
         variables: {
@@ -297,7 +297,7 @@ describe('TaskPage', () => {
         id: 'taskId',
         assignee: 'test',
         name: 'task name',
-        due: moment(),
+        due: dayjs(),
         priority: '1000',
       },
       variables: {
@@ -368,12 +368,12 @@ describe('TaskPage', () => {
     expect(mockNavigate).toBeCalledWith('/tasks');
   });
 
-  it('can update task priority', async () => {
+  it('should update task priority', async () => {
     mockAxios.onGet('/ui/tasks/taskId').reply(200, {
       task: {
         id: 'taskId',
         name: 'Cheese',
-        due: moment(),
+        due: dayjs(),
         priority: '100',
         assignee: null,
       },
@@ -412,6 +412,51 @@ describe('TaskPage', () => {
     expect(mockAxios.history.get.length).toBe(2);
     expect(mockAxios.history.put.length).toBe(1);
     expect(screen.queryByText('Change priority')).not.toBeInTheDocument();
+    expect(screen.queryByText('cancel')).not.toBeInTheDocument();
+    expect(screen.queryByText('Cheese')).toBeInTheDocument();
+  });
+
+  it('should update due date', async () => {
+    mockAxios.onGet('/ui/tasks/taskId').reply(200, {
+      task: {
+        id: 'taskId',
+        name: 'Cheese',
+        due: dayjs().add(1, 'day').format('YYYY-MM-DDTHH:mm:ss.SSS[+0000]'),
+        priority: '100',
+        assignee: null,
+      },
+      processDefinition: {
+        category: 'test',
+      },
+      processInstance: {
+        businessKey: 'BUSINESS KEY',
+      },
+    });
+    mockAxios.onPut('/camunda/engine-rest/task/taskId').reply(204);
+
+    const { container } = render(
+      <AlertContextProvider>
+        <TaskPage taskId="taskId" />
+      </AlertContextProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.queryByText('Change due date')).not.toBeInTheDocument();
+      // There are 2 instances of change on first render, one for due date and one for priority
+      expect(screen.queryAllByText('change')[0]).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getAllByText('change')[0]);
+
+    expect(screen.queryByText('cancel')).toBeInTheDocument();
+    expect(screen.queryByText('Change due date')).toBeInTheDocument();
+
+    fireEvent.change(getById(container, 'month'), { target: { value: '03' } });
+    await waitFor(() => fireEvent.click(screen.getByText('Change due date')));
+
+    expect(mockAxios.history.get.length).toBe(2);
+    expect(mockAxios.history.put.length).toBe(1);
+    expect(screen.queryByText('Change due date')).not.toBeInTheDocument();
     expect(screen.queryByText('cancel')).not.toBeInTheDocument();
     expect(screen.queryByText('Cheese')).toBeInTheDocument();
   });

--- a/client/src/pages/tasks/components/ChangeDueDate.jsx
+++ b/client/src/pages/tasks/components/ChangeDueDate.jsx
@@ -73,6 +73,7 @@ const ChangeDueDate = ({
               Day
             </label>
             <input
+              id="day"
               className="govuk-input govuk-date-input__input govuk-input--width-2"
               type="text"
               pattern="[0-9]*"
@@ -89,6 +90,7 @@ const ChangeDueDate = ({
               Month
             </label>
             <input
+              id="month"
               className="govuk-input govuk-date-input__input govuk-input--width-2"
               type="text"
               pattern="[0-9]*"
@@ -105,6 +107,7 @@ const ChangeDueDate = ({
               Year
             </label>
             <input
+              id="year"
               className="govuk-input govuk-date-input__input govuk-input--width-4"
               type="text"
               pattern="[0-9]*"

--- a/client/src/pages/tasks/components/ChangeDueDate.jsx
+++ b/client/src/pages/tasks/components/ChangeDueDate.jsx
@@ -1,8 +1,23 @@
-import React from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
+import dayjs from 'dayjs';
 import { isOverDue } from './utils';
 
 const ChangeDueDate = ({ isEditingDueDate, taskInfo }) => {
+  const due = dayjs(taskInfo.due);
+  const [dueDate, setDueDate] = useState({
+    day: due.$D,
+    month: due.$M + 1,
+    year: due.$y,
+    hour: due.$H,
+    minute: due.$m,
+    second: due.$s,
+  });
+
+  const handleDueDateChange = (e) => {
+    setDueDate({ ...dueDate, [e.target.name]: e.target.value });
+  };
+
   if (!isEditingDueDate) {
     return <h4 className="govuk-heading-m govuk-!-font-size-19">{isOverDue(taskInfo.due)}</h4>;
   }
@@ -19,6 +34,9 @@ const ChangeDueDate = ({ isEditingDueDate, taskInfo }) => {
               type="text"
               pattern="[0-9]*"
               inputMode="numeric"
+              name="day"
+              value={dueDate.day}
+              onChange={handleDueDateChange}
             />
           </div>
         </div>
@@ -32,6 +50,9 @@ const ChangeDueDate = ({ isEditingDueDate, taskInfo }) => {
               type="text"
               pattern="[0-9]*"
               inputMode="numeric"
+              name="month"
+              value={dueDate.month}
+              onChange={handleDueDateChange}
             />
           </div>
         </div>
@@ -45,6 +66,9 @@ const ChangeDueDate = ({ isEditingDueDate, taskInfo }) => {
               type="text"
               pattern="[0-9]*"
               inputMode="numeric"
+              name="year"
+              value={dueDate.year}
+              onChange={handleDueDateChange}
             />
           </div>
         </div>

--- a/client/src/pages/tasks/components/ChangeDueDate.jsx
+++ b/client/src/pages/tasks/components/ChangeDueDate.jsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import dayjs from 'dayjs';
 import axios from 'axios';
+import { useTranslation } from 'react-i18next';
 import { useAxios } from '../../../utils/hooks';
 import { cleanSubmissionData, isOverDue, isDateValid } from './utils';
 
@@ -11,6 +12,7 @@ const ChangeDueDate = ({
   taskUpdateSubmitted,
   setTaskUpdateSubmitted,
 }) => {
+  const { t } = useTranslation();
   const axiosInstance = useAxios();
   const due = dayjs(taskInfo.due);
   const [dueDate, setDueDate] = useState({
@@ -22,6 +24,7 @@ const ChangeDueDate = ({
     second: due.$s,
     millisecond: due.$ms,
   });
+  const [isError, setIsError] = useState(false);
 
   const handleDueDateChange = (e) => {
     setDueDate({ ...dueDate, [e.target.name]: e.target.value });
@@ -35,7 +38,7 @@ const ChangeDueDate = ({
     const updatedDueDate = `${year}-${`0${month}`.slice(-2)}-${`0${day}`.slice(-2)}`;
 
     if (isDateValid(updatedDueDate, 'YYYY-MM-DD')) {
-      // Add time back on here as only date is changed, not the time in the UI
+      // Add time back on here as only date is changed in the UI, not the time
       cleanedData.due = dayjs(
         `${updatedDueDate}T${hour}:${minute}:${second}.${millisecond}`
       ).format('YYYY-MM-DDTHH:mm:ss.SSS[+0000]');
@@ -47,6 +50,8 @@ const ChangeDueDate = ({
         data: cleanedData,
       });
       setTaskUpdateSubmitted(!taskUpdateSubmitted);
+    } else {
+      setIsError(true);
     }
   };
 
@@ -54,7 +59,13 @@ const ChangeDueDate = ({
     return <h4 className="govuk-heading-m govuk-!-font-size-19">{isOverDue(taskInfo.due)}</h4>;
   }
   return (
-    <div className="govuk-form-group">
+    <div className={`govuk-form-group ${isError ? 'govuk-form-group--error' : null}`}>
+      {isError && (
+        <span className="govuk-error-message">
+          <span className="govuk-visually-hidden">Error:</span>
+          {t(`pages.task.submission.error.due-date-change`)}
+        </span>
+      )}
       <div className="govuk-date-input">
         <div className="govuk-date-input__item">
           <div className="govuk-form-group">

--- a/client/src/pages/tasks/components/ChangeDueDate.jsx
+++ b/client/src/pages/tasks/components/ChangeDueDate.jsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { isOverDue } from './utils';
+
+const ChangeDueDate = ({ isEditingDueDate, taskInfo }) => {
+  if (!isEditingDueDate) {
+    return <h4 className="govuk-heading-m govuk-!-font-size-19">{isOverDue(taskInfo.due)}</h4>;
+  }
+  return (
+    <div className="govuk-form-group">
+      <div className="govuk-date-input">
+        <div className="govuk-date-input__item">
+          <div className="govuk-form-group">
+            <label className="govuk-label govuk-date-input__label" htmlFor="day">
+              Day
+            </label>
+            <input
+              className="govuk-input govuk-date-input__input govuk-input--width-2"
+              type="text"
+              pattern="[0-9]*"
+              inputMode="numeric"
+            />
+          </div>
+        </div>
+        <div className="govuk-date-input__item">
+          <div className="govuk-form-group">
+            <label className="govuk-label govuk-date-input__label" htmlFor="month">
+              Month
+            </label>
+            <input
+              className="govuk-input govuk-date-input__input govuk-input--width-2"
+              type="text"
+              pattern="[0-9]*"
+              inputMode="numeric"
+            />
+          </div>
+        </div>
+        <div className="govuk-date-input__item">
+          <div className="govuk-form-group">
+            <label className="govuk-label govuk-date-input__label" htmlFor="year">
+              Year
+            </label>
+            <input
+              className="govuk-input govuk-date-input__input govuk-input--width-4"
+              type="text"
+              pattern="[0-9]*"
+              inputMode="numeric"
+            />
+          </div>
+        </div>
+      </div>
+      <button className="govuk-button govuk-!-margin-top-2" type="submit">
+        Change due date
+      </button>
+    </div>
+  );
+};
+
+ChangeDueDate.propTypes = {
+  isEditingDueDate: PropTypes.bool.isRequired,
+  taskInfo: PropTypes.shape({
+    due: PropTypes.string.isRequired,
+  }).isRequired,
+};
+
+export default ChangeDueDate;

--- a/client/src/pages/tasks/components/ChangeDueDate.test.jsx
+++ b/client/src/pages/tasks/components/ChangeDueDate.test.jsx
@@ -1,0 +1,96 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor, queryByAttribute } from '@testing-library/react';
+import axios from 'axios';
+import MockAdapter from 'axios-mock-adapter';
+import dayjs from 'dayjs';
+import ChangeDueDate from './ChangeDueDate';
+
+describe('ChangeDueDate', () => {
+  const getById = queryByAttribute.bind(null, 'id');
+  const mockAxios = new MockAdapter(axios);
+  const mockSetTaskUpdateSubmitted = jest.fn();
+  const mockProps = {
+    isEditingDueDate: true,
+    taskInfo: {
+      id: 'taskId',
+      priority: 100,
+      name: 'name',
+      due: dayjs().add(1, 'day').format('YYYY-MM-DDTHH:mm:ss.SSS[+0000]'),
+      description: 'description',
+      assignee: 'assignee',
+      owner: 'owner',
+      delegationState: 'delegationState',
+      followUp: 'followUp',
+      parentTaskId: 'parentTaskId',
+      caseInstanceId: 'caseInstanceId',
+      tenantId: 'tenantId',
+    },
+    taskUpdateSubmitted: false,
+    setTaskUpdateSubmitted: mockSetTaskUpdateSubmitted,
+  };
+
+  beforeEach(() => {
+    mockAxios.reset();
+  });
+
+  it('should render without error', () => {
+    render(<ChangeDueDate {...mockProps} />);
+  });
+
+  it('should only display the tasks relative due date when the due date is not being updated', () => {
+    // isEditingDueDate default set to true for testing, majority of tests are for when the date inputs ARE rendered
+    const props = { ...mockProps, isEditingDueDate: false };
+
+    render(<ChangeDueDate {...props} />);
+
+    expect(screen.queryByText('Due in a day')).toBeInTheDocument();
+    expect(screen.queryByText('Change due date')).not.toBeInTheDocument();
+  });
+
+  it('should handle date input change', () => {
+    const { container } = render(<ChangeDueDate {...mockProps} />);
+
+    fireEvent.change(getById(container, 'day'), { target: { value: '19' } });
+    fireEvent.change(getById(container, 'month'), { target: { value: '03' } });
+    fireEvent.change(getById(container, 'year'), { target: { value: '1995' } });
+
+    expect(screen.queryByDisplayValue('19')).toBeInTheDocument();
+    expect(screen.queryByDisplayValue('03')).toBeInTheDocument();
+    expect(screen.queryByDisplayValue('1995')).toBeInTheDocument();
+  });
+
+  it('should submit due date change successfully', async () => {
+    mockAxios.onPut('/camunda/engine-rest/task/taskId').reply(204);
+
+    const { container } = render(<ChangeDueDate {...mockProps} />);
+
+    fireEvent.change(getById(container, 'day'), { target: { value: '19' } });
+    fireEvent.change(getById(container, 'month'), { target: { value: '03' } });
+    fireEvent.change(getById(container, 'year'), { target: { value: '1995' } });
+    await waitFor(() => fireEvent.click(screen.getByText('Change due date')));
+
+    expect(mockAxios.history.put.length).toBe(1);
+    expect(
+      screen.queryByText('pages.task.submission.error.due-date-change')
+    ).not.toBeInTheDocument();
+
+    // Time and time zone value is fixed so is grabbed here to check req payload is correct
+    const timeAndTimeZone = mockProps.taskInfo.due.split('T')[1];
+    const requestPayload = JSON.parse(mockAxios.history.put[0].data);
+
+    expect(requestPayload.due).toBe(`1995-03-19T${timeAndTimeZone}`);
+  });
+
+  it('should handle date input errors gracefully', async () => {
+    mockAxios.onPut('/camunda/engine-rest/task/taskId').reply(204);
+
+    const { container } = render(<ChangeDueDate {...mockProps} />);
+
+    fireEvent.change(getById(container, 'day'), { target: { value: '100' } });
+    await waitFor(() => fireEvent.click(screen.getByText('Change due date')));
+
+    expect(screen.queryByText('pages.task.submission.error.due-date-change')).toBeInTheDocument();
+    // We don't expect any call to be made
+    expect(mockAxios.history.put.length).toBe(0);
+  });
+});

--- a/client/src/pages/tasks/components/ChangePriority.jsx
+++ b/client/src/pages/tasks/components/ChangePriority.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import axios from 'axios';
 import { useAxios } from '../../../utils/hooks';
 import determinePriority from '../../../utils/priority';
+import { cleanSubmissionData } from './utils';
 
 const ChangePriority = ({
   isEditingPriority,
@@ -13,27 +14,6 @@ const ChangePriority = ({
   const axiosInstance = useAxios();
   const [updatedTaskInfo, setUpdatedTaskInfo] = useState(taskInfo);
 
-  const cleanSubmissionData = (submissionData) => {
-    const propsToKeep = [
-      'name',
-      'description',
-      'priority',
-      'assignee',
-      'owner',
-      'delegationState',
-      'due',
-      'followUp',
-      'parentTaskId',
-      'caseInstanceId',
-      'tenantId',
-    ];
-    const result = {};
-
-    propsToKeep.forEach((key) => {
-      result[key] = submissionData[key];
-    });
-    return result;
-  };
   const submitPriorityChange = async () => {
     const cleanedData = cleanSubmissionData(updatedTaskInfo);
     const source = axios.CancelToken.source();

--- a/client/src/pages/tasks/components/ChangePriority.jsx
+++ b/client/src/pages/tasks/components/ChangePriority.jsx
@@ -14,7 +14,8 @@ const ChangePriority = ({
   const axiosInstance = useAxios();
   const [updatedTaskInfo, setUpdatedTaskInfo] = useState(taskInfo);
 
-  const submitPriorityChange = async () => {
+  const submitPriorityChange = async (e) => {
+    e.preventDefault();
     const cleanedData = cleanSubmissionData(updatedTaskInfo);
     const source = axios.CancelToken.source();
     await axiosInstance({

--- a/client/src/pages/tasks/components/TaskListItem.jsx
+++ b/client/src/pages/tasks/components/TaskListItem.jsx
@@ -7,6 +7,7 @@ import axios from 'axios';
 import { useKeycloak } from '@react-keycloak/web';
 import { useAxios } from '../../../utils/hooks';
 import './TaskListItem.scss';
+import { isOverDue } from './utils';
 
 dayjs.extend(relativeTime);
 
@@ -17,26 +18,6 @@ const TaskListItem = ({ id, due, name, assignee, businessKey }) => {
   const currentUser = keycloak.tokenParsed.email;
   const [unclaimActionMade, setUnclaimActionMade] = useState(false);
 
-  const isOverDue = () => {
-    if (dayjs(due).fromNow().includes('ago')) {
-      return (
-        <span
-          aria-label={`due ${dayjs(due).fromNow()}`}
-          className="govuk-!-font-size-19 govuk-!-font-weight-bold overdue"
-        >
-          {`Overdue ${dayjs(due).fromNow()}`}
-        </span>
-      );
-    }
-    return (
-      <span
-        aria-label={`due ${dayjs(due).fromNow()}`}
-        className="govuk-!-font-size-19 govuk-!-font-weight-bold not-overdue"
-      >
-        {`Due ${dayjs(due).fromNow()}`}
-      </span>
-    );
-  };
   const isAssigned = () => {
     if (!assignee || unclaimActionMade) {
       return 'Unassigned';
@@ -100,7 +81,9 @@ const TaskListItem = ({ id, due, name, assignee, businessKey }) => {
       </div>
       <div className="govuk-grid-column-one-half">
         <div className="govuk-grid-row">
-          <div className="govuk-grid-column-one-third govuk-!-margin-bottom-3">{isOverDue()}</div>
+          <div className="govuk-grid-column-one-third govuk-!-margin-bottom-3">
+            {isOverDue(due)}
+          </div>
           <div className="govuk-grid-column-one-third govuk-!-margin-bottom-3">
             <span className="govuk-!-font-size-19 govuk-!-font-weight-bold">{isAssigned()}</span>
           </div>

--- a/client/src/pages/tasks/components/TaskPageSummary.jsx
+++ b/client/src/pages/tasks/components/TaskPageSummary.jsx
@@ -60,7 +60,12 @@ const TaskPageSummary = ({
             </button>
             )
           </span>
-          <ChangeDueDate isEditingDueDate={isEditingDueDate} taskInfo={taskInfo} />
+          <ChangeDueDate
+            isEditingDueDate={isEditingDueDate}
+            taskInfo={taskInfo}
+            taskUpdateSubmitted={taskUpdateSubmitted}
+            setTaskUpdateSubmitted={setTaskUpdateSubmitted}
+          />
         </div>
         <div className="govuk-grid-column-one-quarter" id="taskPriority">
           <span className="govuk-caption-m govuk-!-font-size-19">

--- a/client/src/pages/tasks/components/TaskPageSummary.jsx
+++ b/client/src/pages/tasks/components/TaskPageSummary.jsx
@@ -15,8 +15,12 @@ const TaskPageSummary = ({
 }) => {
   const { t } = useTranslation();
   const [isEditingPriority, setIsEditingPriority] = useState(false);
+  const [isEditingDueDate, setIsEditingDueDate] = useState(false);
   const handlePriorityEdit = () => {
     setIsEditingPriority(!isEditingPriority);
+  };
+  const handleDueDateEdit = () => {
+    setIsEditingDueDate(!isEditingDueDate);
   };
 
   return (
@@ -42,7 +46,20 @@ const TaskPageSummary = ({
           <h4 className="govuk-heading-m govuk-!-font-size-19">{category}</h4>
         </div>
         <div className="govuk-grid-column-one-quarter" id="taskDueDate">
-          <span className="govuk-caption-m govuk-!-font-size-19">{t('pages.task.due')}</span>
+          <span className="govuk-caption-m govuk-!-font-size-19">
+            {t('pages.task.due')}
+            &nbsp; (
+            <button
+              className="govuk-accordion__open-all"
+              aria-hidden="true"
+              type="button"
+              onClick={handleDueDateEdit}
+              onKeyDown={handleDueDateEdit}
+            >
+              {isEditingDueDate ? 'cancel' : 'change'}
+            </button>
+            )
+          </span>
           <h4 className="govuk-heading-m govuk-!-font-size-19">
             {moment().to(moment(taskInfo.due))}
           </h4>

--- a/client/src/pages/tasks/components/TaskPageSummary.jsx
+++ b/client/src/pages/tasks/components/TaskPageSummary.jsx
@@ -2,8 +2,8 @@ import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-navi';
-import moment from 'moment';
 import ChangePriority from './ChangePriority';
+import ChangeDueDate from './ChangeDueDate';
 
 const TaskPageSummary = ({
   businessKey,
@@ -60,9 +60,7 @@ const TaskPageSummary = ({
             </button>
             )
           </span>
-          <h4 className="govuk-heading-m govuk-!-font-size-19">
-            {moment().to(moment(taskInfo.due))}
-          </h4>
+          <ChangeDueDate isEditingDueDate={isEditingDueDate} taskInfo={taskInfo} />
         </div>
         <div className="govuk-grid-column-one-quarter" id="taskPriority">
           <span className="govuk-caption-m govuk-!-font-size-19">
@@ -78,13 +76,13 @@ const TaskPageSummary = ({
               {isEditingPriority ? 'cancel' : 'change'}
             </button>
             )
-            <ChangePriority
-              isEditingPriority={isEditingPriority}
-              taskInfo={taskInfo}
-              taskUpdateSubmitted={taskUpdateSubmitted}
-              setTaskUpdateSubmitted={setTaskUpdateSubmitted}
-            />
           </span>
+          <ChangePriority
+            isEditingPriority={isEditingPriority}
+            taskInfo={taskInfo}
+            taskUpdateSubmitted={taskUpdateSubmitted}
+            setTaskUpdateSubmitted={setTaskUpdateSubmitted}
+          />
         </div>
         <div className="govuk-grid-column-one-quarter" id="taskAssignee">
           <span className="govuk-caption-m govuk-!-font-size-19">{t('pages.task.assignee')}</span>

--- a/client/src/pages/tasks/components/TaskPageSummary.test.jsx
+++ b/client/src/pages/tasks/components/TaskPageSummary.test.jsx
@@ -33,11 +33,13 @@ describe('TaskPageSummary', () => {
   it('can toggle priority editing', () => {
     render(<TaskPageSummary {...mockProps} />);
 
-    fireEvent.click(screen.getAllByText('change')[0]);
+    // 2 'change' values on initial render, the second 'change' refers to the priority field
+    fireEvent.click(screen.getAllByText('change')[1]);
 
-    // We expect Low, Medium and High to exist here as this signifies the dropdown is rendered
+    // Looking for cancel at 0 index as the due date has not been toggled in this test
     expect(screen.queryAllByText('cancel')[0]).toBeInTheDocument();
     expect(screen.queryByText('Change priority')).toBeInTheDocument();
+    // We expect Low, Medium and High to exist here as this signifies the dropdown is rendered
     expect(screen.queryByText('Low')).toBeInTheDocument();
     expect(screen.queryByText('Medium')).toBeInTheDocument();
     expect(screen.queryByText('High')).toBeInTheDocument();
@@ -45,7 +47,7 @@ describe('TaskPageSummary', () => {
     fireEvent.click(screen.getAllByText('cancel')[0]);
 
     // We expect only Medium to exist here as this signifies the dropdown is not rendered
-    expect(screen.getAllByText('change')[0]).toBeInTheDocument();
+    expect(screen.getAllByText('change')[1]).toBeInTheDocument();
     expect(screen.queryByText('Change priority')).not.toBeInTheDocument();
     expect(screen.queryByText('Low')).not.toBeInTheDocument();
     expect(screen.queryByText('Medium')).toBeInTheDocument();

--- a/client/src/pages/tasks/components/TaskPageSummary.test.jsx
+++ b/client/src/pages/tasks/components/TaskPageSummary.test.jsx
@@ -26,25 +26,25 @@ describe('TaskPageSummary', () => {
     mockAxios.reset();
   });
 
-  it('can render without error', () => {
+  it('should render without error', () => {
     render(<TaskPageSummary {...mockProps} />);
   });
 
-  it('can toggle priority editing', () => {
+  it('should toggle priority editing', () => {
     render(<TaskPageSummary {...mockProps} />);
 
     // 2 'change' values on initial render, the second 'change' refers to the priority field
     fireEvent.click(screen.getAllByText('change')[1]);
 
-    // Looking for cancel at 0 index as the due date has not been toggled in this test
-    expect(screen.queryAllByText('cancel')[0]).toBeInTheDocument();
+    // Should only be one cancel on the screen as due date change has not been toggled
+    expect(screen.queryByText('cancel')).toBeInTheDocument();
     expect(screen.queryByText('Change priority')).toBeInTheDocument();
     // We expect Low, Medium and High to exist here as this signifies the dropdown is rendered
     expect(screen.queryByText('Low')).toBeInTheDocument();
     expect(screen.queryByText('Medium')).toBeInTheDocument();
     expect(screen.queryByText('High')).toBeInTheDocument();
 
-    fireEvent.click(screen.getAllByText('cancel')[0]);
+    fireEvent.click(screen.getByText('cancel'));
 
     // We expect only Medium to exist here as this signifies the dropdown is not rendered
     expect(screen.getAllByText('change')[1]).toBeInTheDocument();
@@ -52,5 +52,22 @@ describe('TaskPageSummary', () => {
     expect(screen.queryByText('Low')).not.toBeInTheDocument();
     expect(screen.queryByText('Medium')).toBeInTheDocument();
     expect(screen.queryByText('High')).not.toBeInTheDocument();
+  });
+
+  it('should toggle due date editing', () => {
+    render(<TaskPageSummary {...mockProps} />);
+
+    fireEvent.click(screen.getAllByText('change')[0]);
+
+    expect(screen.queryByText('cancel')).toBeInTheDocument();
+    expect(screen.queryByText('Change due date')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('cancel'));
+
+    expect(screen.getAllByText('change')[0]).toBeInTheDocument();
+    expect(screen.queryByText('Change due date')).not.toBeInTheDocument();
+    expect(screen.queryByText('Day')).not.toBeInTheDocument();
+    expect(screen.queryByText('Month')).not.toBeInTheDocument();
+    expect(screen.queryByText('Year')).not.toBeInTheDocument();
   });
 });

--- a/client/src/pages/tasks/components/utils.js
+++ b/client/src/pages/tasks/components/utils.js
@@ -45,3 +45,5 @@ export const isOverDue = (due) => {
     </span>
   );
 };
+
+export const isDateValid = (date, format) => dayjs(date).format(format) === date;

--- a/client/src/pages/tasks/components/utils.js
+++ b/client/src/pages/tasks/components/utils.js
@@ -1,0 +1,47 @@
+import dayjs from 'dayjs';
+import relativeTime from 'dayjs/plugin/relativeTime';
+
+dayjs.extend(relativeTime);
+
+export const cleanSubmissionData = (submissionData) => {
+  const propsToKeep = [
+    'name',
+    'description',
+    'priority',
+    'assignee',
+    'owner',
+    'delegationState',
+    'due',
+    'followUp',
+    'parentTaskId',
+    'caseInstanceId',
+    'tenantId',
+  ];
+  const result = {};
+
+  propsToKeep.forEach((key) => {
+    result[key] = submissionData[key];
+  });
+  return result;
+};
+
+export const isOverDue = (due) => {
+  if (dayjs(due).fromNow().includes('ago')) {
+    return (
+      <span
+        aria-label={`due ${dayjs(due).fromNow()}`}
+        className="govuk-!-font-size-19 govuk-!-font-weight-bold overdue"
+      >
+        {`Overdue ${dayjs(due).fromNow()}`}
+      </span>
+    );
+  }
+  return (
+    <span
+      aria-label={`due ${dayjs(due).fromNow()}`}
+      className="govuk-!-font-size-19 govuk-!-font-weight-bold not-overdue"
+    >
+      {`Due ${dayjs(due).fromNow()}`}
+    </span>
+  );
+};


### PR DESCRIPTION
### AC
User is able to update the due date of an existing task

### Updates
- Added `ChangeDueDate` component with accompanying test file
- Added tests in `TaskPage.test.jsx` and `TaskPageSummary.test.jsx` to reflect change due date functionality
- Moved commonly used functions into `tasks/components/utils.js` file
- Replaced several instances of the `moment` package with `dayjs` as part of gradual migration

### Notes
- There is no method for handling invalid due dates in v1, in v2 minor error handling has been added in order to signify an invalid date has been passed

### To test
- Pull and run cop locally
- Login
- Submit form (intel referral or record border event - one that creates a task)
- Go to task created in task list
- Click on task created
### *Scenario 1 - VALID DATE*
- Click on `change` next to the `Due` title
- *You should see a date input and button with the text 'Change due date' appear*
- Change the date to a valid date i.e. tomorrow's date
- Click on `Change due date`
- *You should see the task reload with the updated due date - tomorrows date would say 'Due in a day'*
- *You should not see the date input or 'Change due date' submit button being rendered*
### *Scenario 2 - INVALID DATE*
- Click on `change` next to the `Due` title
- *You should see a date input and button with the text 'Change due date' appear*
- Change the date to an invalid date i.e. 30/2/2021
- Click on `Change due date` 
- *You should see an error rendered with the following message 'Task due date must be a real date'*
- *The date should be submitted*
- Change the date to a valid date
- Click on `Change due date`
- *You should see the task reload with the updated due date*
- *You should not see the date input or 'Change due date' submit button being rendered*
