### PR TITLE
COP-4264 Clear all application local storage on logout

### DIFF
--- a/client/src/components/header/Logout.jsx
+++ b/client/src/components/header/Logout.jsx
@@ -1,6 +1,8 @@
 import { useKeycloak } from '@react-keycloak/web';
+import SecureLocalStorageManager from '../../utils/SecureLocalStorageManager';
 
 const Logout = () => {
+  SecureLocalStorageManager.removeAll();
   const [keycloak] = useKeycloak();
   keycloak.logout({
     redirectUri: window.location.origin.toString(),

--- a/client/src/components/header/Logout.test.jsx
+++ b/client/src/components/header/Logout.test.jsx
@@ -1,9 +1,20 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { render } from '@testing-library/react';
 import Logout from './Logout';
+import SecureLocalStorageManager from '../../utils/SecureLocalStorageManager';
 
 describe('Logout', () => {
-  it('renders without crashing', () => {
-    shallow(<Logout />);
+  it('should render without crashing', () => {
+    render(<Logout />);
+  });
+
+  it('should clear secure local storage on logout', () => {
+    SecureLocalStorageManager.set('test-key-remove', 'test-value-remove');
+    localStorage.setItem('test-key-keep', 'test-value-keep');
+
+    render(<Logout />);
+
+    expect(localStorage.getItem('test-key-remove')).toBeFalsy();
+    expect(localStorage.getItem('test-key-keep')).toBeTruthy();
   });
 });


### PR DESCRIPTION
### AC
When a user logs out local storage used by cop-ui should be removed

### Updates
- Called the `removeAll` method in the `Logout` component
- Added test to `Logout.test.jsx` to check if local storage has been cleared correctly

### To test
- Pull and run cop locally
- Login
- Go to group task list
- Change the task filters to `Latest created date` and `Assignee`
- Refresh page
- *Your task filter selections should persist*
- Go to your task list
- Change the task filters to `Highest priority` and `Priority`
- *Your task filter selections should persist*
- *Dev tools Application local storage should be empty bar i18nextLang*
- Click the `Sign out` button in the header
- Sign back into cop
- Go to group task list
- *Your task filters should be set to `Oldest due date` and `Category`*
- Go to your task list
- *Your task filters should be set to `Oldest due date` and `Category`*