### PR TITLE
COP-4477 Add 'repeat form' functionality

### DIFF
--- a/client/src/components/form/hooks.js
+++ b/client/src/components/form/hooks.js
@@ -14,7 +14,7 @@ export default () => {
   const currentUser = keycloak.tokenParsed.email;
 
   const submitForm = useCallback(
-    ({ submission, form, id, businessKey, handleOnFailure, submitPath }) => {
+    ({ submission, form, id, businessKey, handleOnFailure, handleOnRepeat, submitPath }) => {
       if (form) {
         const variables = {
           [form.name]: {
@@ -40,6 +40,8 @@ export default () => {
                 // We can only ever open one task in this manner and so always take the first available
                 if (response.data.length > 0 && response.data[0].assignee === currentUser) {
                   navigation.navigate(`/tasks/${response.data[0].id}`);
+                } else if (submission.data.submitAgain === true) {
+                  handleOnRepeat();
                 } else {
                   setAlertContext({
                     type: 'form-submission',

--- a/client/src/components/form/hooks.test.jsx
+++ b/client/src/components/form/hooks.test.jsx
@@ -36,10 +36,20 @@ describe('hooks - can submit a form from a new form instance', () => {
       },
     },
   };
+  const submissionWithSubmitAgain = {
+    data: {
+      textField: 'test',
+      form: {
+        submittedBy: 'test@digital.homeoffice.gov.uk',
+      },
+      submitAgain: true,
+    },
+  };
   const form = { name: 'test', id: 'formId' };
   const id = 'formId';
   const businessKey = 'businessKey';
   const handleOnFailure = jest.fn();
+  const handleOnRepeat = jest.fn();
   const submitPath = 'process-definition/key';
 
   // Scenarios
@@ -54,6 +64,7 @@ describe('hooks - can submit a form from a new form instance', () => {
         id,
         businessKey,
         handleOnFailure,
+        handleOnRepeat,
         submitPath,
       });
     });
@@ -74,6 +85,7 @@ describe('hooks - can submit a form from a new form instance', () => {
         id,
         businessKey,
         handleOnFailure,
+        handleOnRepeat,
         submitPath,
       });
     });
@@ -97,6 +109,7 @@ describe('hooks - can submit a form from a new form instance', () => {
         id,
         businessKey,
         handleOnFailure,
+        handleOnRepeat,
         submitPath,
       });
     });
@@ -117,6 +130,7 @@ describe('hooks - can submit a form from a new form instance', () => {
         id,
         businessKey,
         handleOnFailure,
+        handleOnRepeat,
         submitPath,
       });
     });
@@ -140,10 +154,36 @@ describe('hooks - can submit a form from a new form instance', () => {
         id,
         businessKey,
         handleOnFailure,
+        handleOnRepeat,
         submitPath,
       });
     });
     expect(mockNavigate).toHaveBeenCalledWith('/');
+  });
+
+  it('can handle successful submit, and call handleOnRepeat function when submitAgain is true', async () => {
+    mockAxios
+      .onPost('/camunda/engine-rest/process-definition/key/formId/submit-form')
+      .reply(200, {});
+    mockAxios.onGet('/camunda/engine-rest/task?processInstanceBusinessKey=businessKey').reply(200, [
+      {
+        id: 'testId',
+        assignee: 'notUserWhoSubmittedForm',
+      },
+    ]);
+    await act(async () => {
+      result.current.submitForm({
+        submission: submissionWithSubmitAgain,
+        form,
+        id,
+        businessKey,
+        handleOnFailure,
+        handleOnRepeat,
+        submitPath,
+      });
+    });
+
+    expect(handleOnRepeat).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/client/src/pages/forms/FormPage.jsx
+++ b/client/src/pages/forms/FormPage.jsx
@@ -14,6 +14,7 @@ const FormPage = ({ formId }) => {
   const { submitForm } = apiHooks();
   const isMounted = useIsMounted();
   const navigation = useNavigation();
+  const [repeat, setRepeat] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const [pageTitle, setPageTitle] = useState();
 
@@ -31,6 +32,7 @@ const FormPage = ({ formId }) => {
 
   useEffect(() => {
     const source = axios.CancelToken.source();
+    setRepeat(false);
 
     const formPageTitle = async () => {
       if (axiosInstance) {
@@ -90,7 +92,7 @@ const FormPage = ({ formId }) => {
     return () => {
       source.cancel('cancelling request');
     };
-  }, [axiosInstance, formId, setForm, isMounted, setSubmitting]);
+  }, [axiosInstance, formId, setForm, isMounted, setSubmitting, repeat]);
 
   if (form.isLoading) {
     return <ApplicationSpinner />;
@@ -102,6 +104,11 @@ const FormPage = ({ formId }) => {
   const businessKeyComponent = FormioUtils.getComponent(form.data.components, 'businessKey');
   const handleOnFailure = () => {
     setSubmitting(false);
+  };
+  const handleOnRepeat = () => {
+    setSubmitting(false);
+    setRepeat(true);
+    console.log('repeat');
   };
 
   return (
@@ -124,8 +131,9 @@ const FormPage = ({ formId }) => {
             id: formId,
             businessKey: businessKeyComponent ? businessKeyComponent.defaultValue : null,
             handleOnFailure,
-            submitPath: 'process-definition/key'
-          })
+            handleOnRepeat,
+            submitPath: 'process-definition/key',
+          });
         }}
       />
     </>

--- a/client/src/pages/forms/FormPage.jsx
+++ b/client/src/pages/forms/FormPage.jsx
@@ -108,7 +108,7 @@ const FormPage = ({ formId }) => {
   const handleOnRepeat = () => {
     setSubmitting(false);
     setRepeat(true);
-    console.log('repeat');
+    window.scrollTo(0, 0);
   };
 
   return (

--- a/client/src/pages/tasks/TaskPage.jsx
+++ b/client/src/pages/tasks/TaskPage.jsx
@@ -19,6 +19,7 @@ const TaskPage = ({ taskId }) => {
   const navigation = useNavigation();
   const [keycloak] = useKeycloak();
   const currentUser = keycloak.tokenParsed.email;
+  const [repeat, setRepeat] = useState(false);
   const { submitForm } = apiHooks();
   const [submitting, setSubmitting] = useState(false);
   const [assigneeText, setAssigneeText] = useState();
@@ -36,8 +37,9 @@ const TaskPage = ({ taskId }) => {
   useEffect(() => {
     // Reset state so that when task page is reloaded with 'next task' it starts fresh
     const source = axios.CancelToken.source();
-    setTask({ isLoading: true, data: null });
+    setRepeat(false);
     setSubmitting(false);
+    setTask({ isLoading: true, data: null });
 
     // Get task data
     const loadTask = async () => {
@@ -127,7 +129,7 @@ const TaskPage = ({ taskId }) => {
     return () => {
       source.cancel('Cancelling request');
     };
-  }, [axiosInstance, setTask, isMounted, taskId, currentUser, taskUpdateSubmitted]);
+  }, [axiosInstance, setTask, isMounted, taskId, currentUser, taskUpdateSubmitted, repeat]);
 
   if (task.isLoading) {
     return <ApplicationSpinner />;
@@ -148,6 +150,11 @@ const TaskPage = ({ taskId }) => {
 
   const handleOnFailure = () => {
     setSubmitting(false);
+  };
+  const handleOnRepeat = () => {
+    setSubmitting(false);
+    setRepeat(true);
+    window.scrollTo(0, 0);
   };
 
   return (
@@ -186,6 +193,7 @@ const TaskPage = ({ taskId }) => {
                   id: taskId,
                   businessKey: processInstance.businessKey,
                   handleOnFailure,
+                  handleOnRepeat,
                   submitPath: 'task',
                 });
               }}


### PR DESCRIPTION
## AC
When a user selects 'enter another' (api key `submitAgain`) and submits, another instance of the form, with a new businessKey, should be loaded

## Updated
- added a `handleOnRepeat` function to FormPage and TaskPage
- updated `hooks.js` submit to check for `handleOnRepeat`
- updated `hooks.jest.js` to test `handleOnRepeat` is called

## Notes
Covid compliance check is the only form to currently use `submitAgain`

## To Test

- open Covid Compliance Check form
- open your network tab
- fill out form and tick enter another
- submit
- note the businessKey for the submission
> a new version of the form should load
- fill out the form and do NOT tick enter another
- submit
- note the businessKey for this submission
> the two businessKeys should be different
> you should be taken to the dashboard with a confirmation box