### PR TITLE
Fix name of shiftDetailsContext object

### DIFF
--- a/client/src/components/form/DisplayForm.jsx
+++ b/client/src/components/form/DisplayForm.jsx
@@ -107,7 +107,7 @@ const DisplayForm = ({
         subject,
         url,
       },
-      shiftDetailsDataContext: {
+      shiftDetailsContext: {
         email,
         locationid: defaultlocationid,
         phone,


### PR DESCRIPTION
This fixes the issue of some components not being properly pre-filled in, for example, the COVID form.