### PR TITLE
COP-4642 Strip file service prefix in application.tml

### DIFF
--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -27,7 +27,7 @@ zuul:
   routes:
     fileupload-service:
       path: /files/**
-      strip-prefix: false
+      strip-prefix: true
       url: ${fileUploadApi.url:http://localhost:9003}
     refdata-service:
       path: /refdata/**


### PR DESCRIPTION
### AC
The user should be able to attach a file without error

### Updated
- Strips the additional `/files` in the request url sent to the file upload service. 
-  The value of `fileUploadApi.url` has been changed. 

### Notes
- This change fixes the issue of a 404 being returned by the file upload service due to receiving a request url in this format `/files/files/business-key` however, in local env a 500 is returned which seems to be AWS related. This issue may not exist in dev and so the expected result in the test below would be *Attachment should be successful*
- Once merged, this needs to be tested in dev ASAP

### To test
- Pull and run cop locally
- Login
- Fill out an intel referral form, do not submit form
- Select `Yes` on the `Do you have any files you would like to upload to support this event?` question at the end
- Drag a valid file type into the drop zone - i.e. png, pdf, jpg etc.
- *Attachment should be successful OR you should receive a 500 error with a error message in the network tab denoting "Failed to upload file - orig version"*

