### PR TITLE
COP-5040 AttachmentsEaB form returning a 405 on file attachment

### DIFF
--- a/client/src/pages/tasks/TaskPage.jsx
+++ b/client/src/pages/tasks/TaskPage.jsx
@@ -180,6 +180,7 @@ const TaskPage = ({ taskId }) => {
               interpolateContext={{
                 processContext: {
                   variables,
+                  ...variables,
                   instance: processInstance,
                   definition: processDefinition,
                 },


### PR DESCRIPTION
### AC
The user should be able to attach a file successfully when completing the record border event process

### Updated
- Spread the `variables` property in `processContext` so that forms have access to the keys they refer to in the forms themselves

### Notes
- The 'extra' `variables` property is still included to ensure compatibility is maintained for existing forms or processes that may access values via `processContext.variables.ANOTHERKEY`
- The change should work in dev without any error being returned by the file upload service

### To test
- Pull and run cop locally
- Login
- Fill out record border event form electing to attach a file prior to submitting form
- Fill out the proceeding forms until you reach the attachments form
- Attach a file with a type in accordance with the ones listed in the form
- *You should receive a 500 on local with the following error message `Failed to upload file - orig version`*