### PR TITLE
COP-5040 Spread variables property in processContext

### DIFF
--- a/client/src/pages/tasks/TaskPage.jsx
+++ b/client/src/pages/tasks/TaskPage.jsx
@@ -179,6 +179,11 @@ const TaskPage = ({ taskId }) => {
               existingSubmission={formSubmission}
               interpolateContext={{
                 processContext: {
+                  /*
+                   * Spread 'variables' here so processContext has nested properties directly on processContext
+                   * i.e. processContext.recordBorderEvent instead of processContext.variables.recordBorderEvent
+                   */
+                  ...variables,
                   variables,
                   instance: processInstance,
                   definition: processDefinition,

--- a/client/src/pages/tasks/TaskPage.jsx
+++ b/client/src/pages/tasks/TaskPage.jsx
@@ -180,8 +180,11 @@ const TaskPage = ({ taskId }) => {
               interpolateContext={{
                 processContext: {
                   /*
-                   * Spread 'variables' here so processContext has nested properties directly on processContext
-                   * i.e. processContext.recordBorderEvent instead of processContext.variables.recordBorderEvent
+                   * Spread 'variables' and keep 'variables' here so processContext has nested properties directly
+                   * on processContext. Forms/processes make reference to values that exist on 'variables' that
+                   * need to exist on processContext. Forms/processes also make reference to values that need to
+                   * exist on 'variables' directly.
+                   * i.e. processContext.recordBorderEvent and processContext.variables.recordBorderEvent
                    */
                   ...variables,
                   variables,


### PR DESCRIPTION
### AC
The user should be able to attach a file successfully when completing the record border event process

### Updated
- Spread the variables property in processContext so that forms have access to the keys they refer to in the forms themselves

### Notes
- The 'extra' variables property is still included to ensure compatibility is maintained for existing forms or processes that may access values via processContext.variables.ANOTHERKEY
- The change should work in dev without any error being returned by the file upload service

### To test
- Pull and run cop locally
- Login
- Fill out record border event form electing to attach a file prior to submitting form
- Fill out the proceeding forms until you reach the attachments form
- Attach a file with a type in accordance with the ones listed in the form
- *You should receive a 500 on local with the following error message Failed to upload file - orig version*