### PR TITLE
COP-2827+COP-2829: Cases search functionality and history panel

### DIFF
--- a/client/src/pages/cases/CaseDetailsPanel.jsx
+++ b/client/src/pages/cases/CaseDetailsPanel.jsx
@@ -7,17 +7,17 @@ import CaseHistory from './components/CaseHistory';
 import CaseIntro from './components/CaseIntro';
 import CaseMetrics from './components/CaseMetrics';
 
-const CaseDetailsPanel = ({ caseSelected }) => {
+const CaseDetailsPanel = ({ businessKey, processInstances }) => {
   return (
     <>
       <div className="govuk-grid-row govuk-card">
-        <CaseIntro businessKey={caseSelected.businessKey} />
+        <CaseIntro businessKey={businessKey} />
       </div>
       <div className="govuk-grid-row govuk-card govuk-!-margin-top-4">
         <CaseActions />
       </div>
       <div className="govuk-grid-row govuk-card govuk-!-margin-top-4">
-        <CaseHistory caseSelected={caseSelected} />
+        <CaseHistory processInstances={processInstances} businessKey={businessKey} />
       </div>
       <div className="govuk-grid-row govuk-card govuk-!-margin-top-4">
         <CaseAttachments />
@@ -30,7 +30,8 @@ const CaseDetailsPanel = ({ caseSelected }) => {
 };
 
 CaseDetailsPanel.propTypes = {
-  caseSelected: PropTypes.shape(PropTypes.object).isRequired,
+  businessKey: PropTypes.string.isRequired,
+  processInstances: PropTypes.arrayOf(PropTypes.object).isRequired,
 };
 
 export default CaseDetailsPanel;

--- a/client/src/pages/cases/CaseDetailsPanel.jsx
+++ b/client/src/pages/cases/CaseDetailsPanel.jsx
@@ -1,21 +1,23 @@
 import React from 'react';
+import PropTypes from 'prop-types';
+
 import CaseActions from './components/CaseActions';
 import CaseAttachments from './components/CaseAttachments';
 import CaseHistory from './components/CaseHistory';
 import CaseIntro from './components/CaseIntro';
 import CaseMetrics from './components/CaseMetrics';
 
-const CaseDetailsPanel = () => {
+const CaseDetailsPanel = ({ caseSelected }) => {
   return (
     <>
       <div className="govuk-grid-row govuk-card">
-        <CaseIntro />
+        <CaseIntro businessKey={caseSelected.businessKey} />
       </div>
       <div className="govuk-grid-row govuk-card govuk-!-margin-top-4">
         <CaseActions />
       </div>
       <div className="govuk-grid-row govuk-card govuk-!-margin-top-4">
-        <CaseHistory />
+        <CaseHistory caseSelected={caseSelected} />
       </div>
       <div className="govuk-grid-row govuk-card govuk-!-margin-top-4">
         <CaseAttachments />
@@ -26,4 +28,9 @@ const CaseDetailsPanel = () => {
     </>
   );
 };
+
+CaseDetailsPanel.propTypes = {
+  caseSelected: PropTypes.node.isRequired,
+};
+
 export default CaseDetailsPanel;

--- a/client/src/pages/cases/CaseDetailsPanel.jsx
+++ b/client/src/pages/cases/CaseDetailsPanel.jsx
@@ -30,7 +30,7 @@ const CaseDetailsPanel = ({ caseSelected }) => {
 };
 
 CaseDetailsPanel.propTypes = {
-  caseSelected: PropTypes.node.isRequired,
+  caseSelected: PropTypes.shape(PropTypes.object).isRequired,
 };
 
 export default CaseDetailsPanel;

--- a/client/src/pages/cases/CasePage.jsx
+++ b/client/src/pages/cases/CasePage.jsx
@@ -19,8 +19,6 @@ const CasePage = () => {
   const [caseSearchResults, setCaseSearchResults] = useState(null);
   const [caseArray, setCaseArray] = useState(null);
   const [searching, setSearching] = useState(false);
-  // eslint-disable-next-line no-unused-vars
-  const [error, setError] = useState(null);
   const [caseSelected, setCaseSelected] = useState(null);
   const [caseLoading, setCaseLoading] = useState(false);
   const [nextUrl, setNextUrl] = useState('');
@@ -68,7 +66,7 @@ const CasePage = () => {
       const resp = await axiosInstance.get(`/camunda/cases/${businessKey}`);
       setCaseSelected(resp.data);
     } catch (err) {
-      setError(err);
+      setCaseSelected(null);
     } finally {
       setCaseLoading(false);
     }

--- a/client/src/pages/cases/CasePage.jsx
+++ b/client/src/pages/cases/CasePage.jsx
@@ -14,7 +14,7 @@ const CasePage = () => {
   useEffect(() => {
     trackPageView();
   }, []);
-  
+
   const axiosInstance = useAxios();
   const [caseSearchResults, setCaseSearchResults] = useState(null);
   const [caseArray, setCaseArray] = useState(null);
@@ -50,6 +50,10 @@ const CasePage = () => {
     try {
       setCaseSelected(null);
       const resp = await axiosInstance.get(`/camunda/cases${nextQuery}`);
+      // Below line catches the case where the API is returning more cases than are actually present
+      if (!resp.data._embedded) {
+        return;
+      }
       setCaseArray(caseArray.concat(resp.data._embedded ? resp.data._embedded.cases : null));
       setCaseSearchResults(resp.data);
       setNextUrl(resp.data._links.next ? resp.data._links.next.href : null);

--- a/client/src/pages/cases/CasePage.jsx
+++ b/client/src/pages/cases/CasePage.jsx
@@ -19,6 +19,7 @@ const CasePage = () => {
   const [caseSearchResults, setCaseSearchResults] = useState(null);
   const [caseArray, setCaseArray] = useState(null);
   const [searching, setSearching] = useState(false);
+  // eslint-disable-next-line no-unused-vars
   const [error, setError] = useState(null);
   const [caseSelected, setCaseSelected] = useState(null);
   const [caseLoading, setCaseLoading] = useState(false);
@@ -28,6 +29,7 @@ const CasePage = () => {
     if (!input || input.length < 3) {
       setCaseSearchResults(null);
       setCaseSelected(null);
+      setNextUrl(null);
       return;
     }
     try {
@@ -36,7 +38,7 @@ const CasePage = () => {
       const resp = await axiosInstance.get(`/camunda/cases?query=${input}`);
       setCaseSearchResults(resp.data);
       setCaseArray(resp.data._embedded ? resp.data._embedded.cases : null);
-      setNextUrl(resp.data._links.next.href);
+      setNextUrl(resp.data._links.next ? resp.data._links.next.href : null);
     } catch (err) {
       setError(err);
     } finally {
@@ -46,12 +48,13 @@ const CasePage = () => {
 
   const loadMoreCases = async (nextQuery) => {
     try {
+      setCaseSelected(null);
       const resp = await axiosInstance.get(`/camunda/cases${nextQuery}`);
       setCaseArray(caseArray.concat(resp.data._embedded ? resp.data._embedded.cases : null));
       setCaseSearchResults(resp.data);
-      setNextUrl(resp.data._links.next.href);
-    } catch {
-      setError(error);
+      setNextUrl(resp.data._links.next ? resp.data._links.next.href : null);
+    } catch (err) {
+      setError(err);
     }
   };
 

--- a/client/src/pages/cases/CasePage.jsx
+++ b/client/src/pages/cases/CasePage.jsx
@@ -29,7 +29,7 @@ const CasePage = () => {
     if (!input || input.length < 3) {
       setCaseSearchResults(null);
       setCaseSelected(null);
-      setNextUrl(null);
+      setNextUrl('');
       return;
     }
     try {
@@ -38,9 +38,9 @@ const CasePage = () => {
       const resp = await axiosInstance.get(`/camunda/cases?query=${input}`);
       setCaseSearchResults(resp.data);
       setCaseArray(resp.data._embedded ? resp.data._embedded.cases : null);
-      setNextUrl(resp.data._links.next ? resp.data._links.next.href : null);
+      setNextUrl(resp.data._links.next ? resp.data._links.next.href : '');
     } catch (err) {
-      setError(err);
+      setCaseSearchResults(null);
     } finally {
       setSearching(false);
     }
@@ -56,9 +56,9 @@ const CasePage = () => {
       }
       setCaseArray(caseArray.concat(resp.data._embedded ? resp.data._embedded.cases : null));
       setCaseSearchResults(resp.data);
-      setNextUrl(resp.data._links.next ? resp.data._links.next.href : null);
+      setNextUrl(resp.data._links.next ? resp.data._links.next.href : '');
     } catch (err) {
-      setError(err);
+      setCaseSearchResults(null);
     }
   };
 
@@ -106,7 +106,7 @@ const CasePage = () => {
           {searching && <h4 className="govuk-heading-s">Searching for cases...</h4>}
           {!searching && caseSearchResults && (
             <CasesResultsPanel
-              caseSearchResults={caseSearchResults}
+              totalElements={caseSearchResults.page.totalElements}
               caseArray={caseArray}
               getCaseDetails={getCaseDetails}
               loadMoreCases={loadMoreCases}
@@ -116,7 +116,12 @@ const CasePage = () => {
         </div>
         <div className="govuk-grid-column-three-quarters">
           {caseLoading && <h4 className="govuk-heading-s">Loading case details</h4>}
-          {!caseLoading && caseSelected && <CaseDetailsPanel caseSelected={caseSelected} />}
+          {!caseLoading && caseSelected && (
+            <CaseDetailsPanel
+              businessKey={caseSelected.businessKey}
+              processInstances={caseSelected.processInstances}
+            />
+          )}
         </div>
       </div>
     </>

--- a/client/src/pages/cases/CasePage.test.jsx
+++ b/client/src/pages/cases/CasePage.test.jsx
@@ -34,6 +34,9 @@ describe('CasePage', () => {
           { businessKey: 'businessKey3', processInstance: [] },
         ],
       },
+      _links: {
+        last: { href: 'url' },
+      },
     });
     render(<CasePage />);
     const input = screen.getByPlaceholderText('pages.cases.search-placeholder');
@@ -56,6 +59,9 @@ describe('CasePage', () => {
         totalElements: 0,
         totalPages: 0,
         number: 0,
+      },
+      _links: {
+        last: { href: 'url' },
       },
     });
     render(<CasePage />);

--- a/client/src/pages/cases/CasePage.test.jsx
+++ b/client/src/pages/cases/CasePage.test.jsx
@@ -1,13 +1,89 @@
 import React from 'react';
 import { shallow } from 'enzyme';
+import { render, waitFor, screen, fireEvent } from '@testing-library/react';
+import MockAdapter from 'axios-mock-adapter';
+import axios from 'axios';
 import CasePage from './CasePage';
+import { AlertContextProvider } from '../../utils/AlertContext';
+import AlertBanner from '../../components/alert/AlertBanner';
 
 describe('CasePage', () => {
+  const mockAxios = new MockAdapter(axios);
+
   beforeEach(() => {
     jest.spyOn(console, 'error').mockImplementation(() => {});
+    mockAxios.reset();
   });
 
   it('renders without crashing', () => {
     shallow(<CasePage caseId="id" />);
+  });
+
+  it('renders results of case search when applicable', async () => {
+    mockAxios.onGet('/camunda/cases?query=keyword').reply(200, {
+      page: {
+        size: 20,
+        totalElements: 3,
+        totalPages: 1,
+        number: 0,
+      },
+      _embedded: {
+        cases: [
+          { businessKey: 'businessKey1', processInstance: [] },
+          { businessKey: 'businessKey2', processInstance: [] },
+          { businessKey: 'businessKey3', processInstance: [] },
+        ],
+      },
+    });
+    render(<CasePage />);
+    const input = screen.getByPlaceholderText('pages.cases.search-placeholder');
+
+    fireEvent.change(input, { target: { value: 'keyword' } });
+
+    await waitFor(() => {
+      expect(screen.getByText('pages.cases.results-panel.title')).toBeTruthy();
+      expect(screen.getByText('3')).toBeTruthy();
+      expect(screen.getByText('businessKey1')).toBeTruthy();
+      expect(screen.getByText('businessKey2')).toBeTruthy();
+      expect(screen.getByText('businessKey3')).toBeTruthy();
+    });
+  });
+
+  it('gracefully renders when no case search results', async () => {
+    mockAxios.onGet('/camunda/cases?query=noResults').reply(200, {
+      page: {
+        size: 20,
+        totalElements: 0,
+        totalPages: 0,
+        number: 0,
+      },
+    });
+    render(<CasePage />);
+    const input = screen.getByPlaceholderText('pages.cases.search-placeholder');
+
+    fireEvent.change(input, { target: { value: 'noResults' } });
+
+    await waitFor(() => {
+      expect(screen.getByText('pages.cases.results-panel.title')).toBeTruthy();
+      expect(screen.getByText('0')).toBeTruthy();
+    });
+  });
+
+  it('renders error message if case search returns an error', async () => {
+    mockAxios.onGet('/camunda/cases?query=keywordError').reply(500, null);
+
+    render(
+      <AlertContextProvider>
+        <AlertBanner />
+        <CasePage />
+      </AlertContextProvider>
+    );
+    const input = screen.getByPlaceholderText('pages.cases.search-placeholder');
+
+    fireEvent.change(input, { target: { value: 'keywordError' } });
+
+    await waitFor(() => {
+      expect(screen.getByText('error.api.title')).toBeTruthy();
+    });
   });
 });

--- a/client/src/pages/cases/CaseResultsPanel.test.jsx
+++ b/client/src/pages/cases/CaseResultsPanel.test.jsx
@@ -30,6 +30,9 @@ describe('CaseResultsPage', () => {
           { businessKey: 'businessKey3', processInstance: [] },
         ],
       },
+      _links: {
+        last: { href: 'url' },
+      },
     });
 
     mockAxios.onGet('/camunda/cases/businessKey1').reply(200, {
@@ -172,6 +175,9 @@ describe('CaseResultsPage', () => {
       },
       _embedded: {
         cases: [{ businessKey: 'businessKey4', processInstance: [] }],
+      },
+      _links: {
+        last: { href: 'url' },
       },
     });
 

--- a/client/src/pages/cases/CaseResultsPanel.test.jsx
+++ b/client/src/pages/cases/CaseResultsPanel.test.jsx
@@ -75,7 +75,7 @@ describe('CaseResultsPage', () => {
       expect(screen.getByText('businessKey1')).toBeTruthy();
     });
 
-    // Renders Case Details Panel when user clicks case link
+    // Renders Case Details Panel when user selects a case link
     const caseSelected = screen.getByText('businessKey1');
     fireEvent.click(caseSelected);
 
@@ -84,6 +84,7 @@ describe('CaseResultsPage', () => {
 
     await waitFor(() => {
       expect(screen.getByText('Submit Intelligence Referral')).toBeTruthy();
+      expect(screen.getByText('Enhance intel')).toBeTruthy();
     });
   });
 
@@ -138,7 +139,7 @@ describe('CaseResultsPage', () => {
       </CasePage>
     );
 
-    // Renders list of case search results when user inputs a query
+    // Renders first page of case search results when user inputs a query
     const input = screen.getByPlaceholderText('pages.cases.search-placeholder');
     fireEvent.change(input, { target: { value: 'multiPageResults' } });
 
@@ -149,10 +150,11 @@ describe('CaseResultsPage', () => {
       expect(screen.getAllByText('Load more')).toBeTruthy();
     });
 
-    // Load More button is visible and loads more cases when clicked
+    // Load More button is visible
     const loadMoreButton = screen.getByText('Load more');
     fireEvent.click(loadMoreButton);
 
+    // Loads more cases when 'Load more' is clicked
     await waitFor(() => {
       expect(screen.getByText('businessKey25')).toBeTruthy();
       expect(screen.getByText('40')).toBeTruthy();
@@ -160,7 +162,7 @@ describe('CaseResultsPage', () => {
     });
   });
 
-  it('renders error message if case details returns an error', async () => {
+  it('renders error message if Case Details API returns an error', async () => {
     mockAxios.onGet('/camunda/cases?query=keyword').reply(200, {
       page: {
         size: 20,

--- a/client/src/pages/cases/CaseResultsPanel.test.jsx
+++ b/client/src/pages/cases/CaseResultsPanel.test.jsx
@@ -1,0 +1,198 @@
+import React from 'react';
+import { render, waitFor, screen, fireEvent } from '@testing-library/react';
+import MockAdapter from 'axios-mock-adapter';
+import axios from 'axios';
+import CaseResultsPanel from './CasesResultsPanel';
+import CasePage from './CasePage';
+import { AlertContextProvider } from '../../utils/AlertContext';
+import AlertBanner from '../../components/alert/AlertBanner';
+
+describe('CaseResultsPage', () => {
+  const mockAxios = new MockAdapter(axios);
+
+  beforeEach(() => {
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+    mockAxios.reset();
+  });
+
+  it('renders case results list and displays Case Details when selected ', async () => {
+    mockAxios.onGet('/camunda/cases?query=keyword').reply(200, {
+      page: {
+        size: 20,
+        totalElements: 3,
+        totalPages: 1,
+        number: 0,
+      },
+      _embedded: {
+        cases: [
+          { businessKey: 'businessKey1', processInstance: [] },
+          { businessKey: 'businessKey2', processInstance: [] },
+          { businessKey: 'businessKey3', processInstance: [] },
+        ],
+      },
+    });
+
+    mockAxios.onGet('/camunda/cases/businessKey1').reply(200, {
+      businessKey: 'businessKey1',
+      processInstances: [
+        {
+          definitionId: 'intel-referral:3:85c1a0aa-34bb-11eb-924e-e61a6d54c1b3',
+          endDate: '2021-01-13T10:25:25.065+0000',
+          formReferences: [{ name: 'intelligenceReferral', title: 'Intelligence Referral' }],
+          id: 'e7e417c4-356b-11eb-b768-863d861ec96a',
+          key: 'intel-referral',
+          name: 'Submit Intelligence Referral',
+          openTasks: [],
+          startDate: '2020-12-03T13:31:53.319+0000',
+        },
+        {
+          definitionId: 'enhance-intel:2:c2d7a5b0-27f7-11eb-b6c2-922e59dab112',
+          endDate: '2021-01-13T10:25:24.993+0000',
+          formReferences: [],
+          id: 'e806bb0c-356b-11eb-b768-863d861ec96a',
+          key: 'enhance-intel',
+          name: 'Enhance intel',
+          openTasks: [],
+          startDate: '2020-12-03T13:31:53.546+0000',
+        },
+      ],
+    });
+
+    render(
+      <CasePage>
+        <CaseResultsPanel />
+      </CasePage>
+    );
+
+    // Renders list of case search results on user input
+    const input = screen.getByPlaceholderText('pages.cases.search-placeholder');
+
+    fireEvent.change(input, { target: { value: 'keyword' } });
+
+    await waitFor(() => {
+      expect(screen.getByText('pages.cases.results-panel.title')).toBeTruthy();
+      expect(screen.getByText('3')).toBeTruthy();
+      expect(screen.getByText('businessKey1')).toBeTruthy();
+    });
+
+    // Renders Case Details Panel when user clicks case link
+    const caseSelected = screen.getByText('businessKey1');
+    fireEvent.click(caseSelected);
+
+    // Displays message when loading case details
+    expect(screen.getByText('Loading case details')).toBeTruthy();
+
+    await waitFor(() => {
+      expect(screen.getByText('Submit Intelligence Referral')).toBeTruthy();
+    });
+  });
+
+  it('loads more cases when multi page Case search results', async () => {
+    // Set up mock data for two pages of search results
+    const mockData = {
+      page: {
+        size: 20,
+        totalElements: 40,
+        totalPages: 2,
+        number: 0,
+      },
+      _embedded: {
+        cases: [],
+      },
+      _links: {
+        next: { href: '/camunda/cases?query=multiPageResults&page=1&size=20' },
+        last: { href: '/camunda/cases?query=multiPageResults&page=1&size=20' },
+      },
+    };
+    for (let i = 1; i < 20; i += 1) {
+      mockData._embedded.cases.push({ businessKey: `businessKey${i}`, processInstance: [] });
+    }
+
+    const mockDataPageTwo = {
+      page: {
+        size: 20,
+        totalElements: 40,
+        totalPages: 2,
+        number: 1,
+      },
+      _embedded: {
+        cases: [],
+      },
+      _links: {
+        last: { href: '/camunda/cases?query=multiPageResults&page=1&size=20' },
+      },
+    };
+
+    for (let i = 20; i <= 40; i += 1) {
+      mockDataPageTwo._embedded.cases.push({ businessKey: `businessKey${i}`, processInstance: [] });
+    }
+
+    mockAxios.onGet('/camunda/cases?query=multiPageResults').reply(200, mockData);
+    mockAxios
+      .onGet('/camunda/cases?query=multiPageResults&page=1&size=20')
+      .reply(200, mockDataPageTwo);
+
+    render(
+      <CasePage>
+        <CaseResultsPanel />
+      </CasePage>
+    );
+
+    // Renders list of case search results when user inputs a query
+    const input = screen.getByPlaceholderText('pages.cases.search-placeholder');
+    fireEvent.change(input, { target: { value: 'multiPageResults' } });
+
+    await waitFor(() => {
+      expect(screen.getByText('pages.cases.results-panel.title')).toBeTruthy();
+      expect(screen.getByText('40')).toBeTruthy();
+      expect(screen.getByText('businessKey9')).toBeTruthy();
+      expect(screen.getAllByText('Load more')).toBeTruthy();
+    });
+
+    // Load More button is visible and loads more cases when clicked
+    const loadMoreButton = screen.getByText('Load more');
+    fireEvent.click(loadMoreButton);
+
+    await waitFor(() => {
+      expect(screen.getByText('businessKey25')).toBeTruthy();
+      expect(screen.getByText('40')).toBeTruthy();
+      expect(screen.queryByText('Load more')).toBeNull();
+    });
+  });
+
+  it('renders error message if case details returns an error', async () => {
+    mockAxios.onGet('/camunda/cases?query=keyword').reply(200, {
+      page: {
+        size: 20,
+        totalElements: 3,
+        totalPages: 1,
+        number: 0,
+      },
+      _embedded: {
+        cases: [{ businessKey: 'businessKey4', processInstance: [] }],
+      },
+    });
+
+    mockAxios.onGet('/camunda/cases/businessKey4').reply(500, null);
+
+    render(
+      <AlertContextProvider>
+        <AlertBanner />
+        <CasePage />
+      </AlertContextProvider>
+    );
+
+    const input = screen.getByPlaceholderText('pages.cases.search-placeholder');
+    fireEvent.change(input, { target: { value: 'keyword' } });
+
+    await waitFor(() => {
+      expect(screen.getByText('businessKey4')).toBeTruthy();
+    });
+    const caseSelected = screen.getByText('businessKey4');
+    fireEvent.click(caseSelected);
+
+    await waitFor(() => {
+      expect(screen.getByText('error.api.title')).toBeTruthy();
+    });
+  });
+});

--- a/client/src/pages/cases/CasesPage.scss
+++ b/client/src/pages/cases/CasesPage.scss
@@ -2,6 +2,8 @@
 @import '~govuk-frontend/govuk/settings/_colours-applied.scss';
 $govuk-card-border : govuk-colour('blue');
 
+@import '~govuk-frontend/govuk/all';
+
 .search__input {
   position: relative;
   background-repeat: no-repeat;

--- a/client/src/pages/cases/CasesResultsPanel.jsx
+++ b/client/src/pages/cases/CasesResultsPanel.jsx
@@ -1,24 +1,15 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import PropTypes from 'prop-types';
-import _ from 'lodash';
 
-const CaseResultsPanel = ({
-  caseSearchResults,
-  caseArray,
-  getCaseDetails,
-  loadMoreCases,
-  nextUrl,
-}) => {
+const CaseResultsPanel = ({ totalElements, caseArray, getCaseDetails, loadMoreCases, nextUrl }) => {
   const { t } = useTranslation();
-  // Check if caseSearchResults.links has property 'next'
-  const hasMoreData = _.has(caseSearchResults._links, 'next');
 
   return (
     <>
       <h2 className="govuk-heading-m">{t('pages.cases.results-panel.title')}</h2>
       <p className="govuk-body govuk-!-margin-bottom-1">{t('pages.cases.results-panel.caption')}</p>
-      <p className="govuk-body govuk-!-font-weight-bold">{caseSearchResults.page.totalElements}</p>
+      <p className="govuk-body govuk-!-font-weight-bold">{totalElements}</p>
       <ul className="govuk-list">
         {caseArray &&
           caseArray.map((item) => {
@@ -39,7 +30,7 @@ const CaseResultsPanel = ({
             );
           })}
       </ul>
-      {hasMoreData ? (
+      {nextUrl ? (
         <button
           type="button"
           className="govuk-button"
@@ -57,11 +48,10 @@ const CaseResultsPanel = ({
 
 CaseResultsPanel.defaultProps = {
   caseArray: null,
-  caseSearchResults: null,
 };
 
 CaseResultsPanel.propTypes = {
-  caseSearchResults: PropTypes.shape(PropTypes.object),
+  totalElements: PropTypes.number.isRequired,
   caseArray: PropTypes.arrayOf(PropTypes.object),
   getCaseDetails: PropTypes.func.isRequired,
   loadMoreCases: PropTypes.func.isRequired,

--- a/client/src/pages/cases/CasesResultsPanel.jsx
+++ b/client/src/pages/cases/CasesResultsPanel.jsx
@@ -1,16 +1,71 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
+import PropTypes from 'prop-types';
+import _ from 'lodash';
 
-const CaseResultsPanel = () => {
+const CaseResultsPanel = ({
+  caseSearchResults,
+  caseArray,
+  getCaseDetails,
+  loadMoreCases,
+  nextUrl,
+}) => {
   const { t } = useTranslation();
+  // Check if caseSearchResults.links has property 'next'
+  const hasMoreData = _.has(caseSearchResults._links, 'next');
 
   return (
     <>
       <h2 className="govuk-heading-m">{t('pages.cases.results-panel.title')}</h2>
       <p className="govuk-body govuk-!-margin-bottom-1">{t('pages.cases.results-panel.caption')}</p>
-      <p className="govuk-body govuk-!-font-weight-bold">0</p>
+      <p className="govuk-body govuk-!-font-weight-bold">{caseSearchResults.page.totalElements}</p>
+      <ul className="govuk-list">
+        {caseArray &&
+          caseArray.map((item) => {
+            return (
+              <li key={item.businessKey}>
+                {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
+                <a
+                  href=""
+                  className="govuk-link"
+                  onClick={(e) => {
+                    e.preventDefault();
+                    getCaseDetails(item.businessKey);
+                  }}
+                >
+                  {item.businessKey}
+                </a>
+              </li>
+            );
+          })}
+      </ul>
+      {hasMoreData ? (
+        <button
+          type="button"
+          className="govuk-button"
+          onClick={(e) => {
+            e.preventDefault();
+            loadMoreCases(nextUrl.slice(nextUrl.indexOf('?')));
+          }}
+        >
+          Load more
+        </button>
+      ) : null}
     </>
   );
+};
+
+CaseResultsPanel.defaultProps = {
+  caseArray: null,
+  caseSearchResults: null,
+};
+
+CaseResultsPanel.propTypes = {
+  caseSearchResults: PropTypes.shape(PropTypes.object),
+  caseArray: PropTypes.arrayOf(PropTypes.object),
+  getCaseDetails: PropTypes.func.isRequired,
+  loadMoreCases: PropTypes.func.isRequired,
+  nextUrl: PropTypes.string.isRequired,
 };
 
 export default CaseResultsPanel;

--- a/client/src/pages/cases/components/CaseHistory.jsx
+++ b/client/src/pages/cases/components/CaseHistory.jsx
@@ -118,7 +118,7 @@ const CaseHistory = ({ caseSelected }) => {
 };
 
 CaseHistory.propTypes = {
-  caseSelected: PropTypes.node.isRequired,
+  caseSelected: PropTypes.shape(PropTypes.object).isRequired,
 };
 
 export default CaseHistory;

--- a/client/src/pages/cases/components/CaseHistory.jsx
+++ b/client/src/pages/cases/components/CaseHistory.jsx
@@ -1,8 +1,25 @@
-import React from 'react';
+import React, { useEffect } from 'react';
+import PropTypes from 'prop-types';
 import { useTranslation } from 'react-i18next';
+import _ from 'lodash';
+import moment from 'moment';
+import { Accordion } from 'govuk-frontend';
+import FormDetails from './FormDetails';
 
-const CaseHistory = () => {
+const CaseHistory = ({ caseSelected }) => {
   const { t } = useTranslation();
+  const clearAccordionStorage = () => {
+    _.forIn(window.sessionStorage, (value, key) => {
+      if (_.startsWith(key, 'caseSelected-') === true) {
+        window.sessionStorage.removeItem(key);
+      }
+    });
+  };
+
+  useEffect(() => {
+    clearAccordionStorage();
+    new Accordion(document.getElementById(`caseSelected-${caseSelected.businessKey}`)).init();
+  });
 
   return (
     <>
@@ -25,17 +42,83 @@ const CaseHistory = () => {
             </select>
           </label>
         </div>
-        <div id="businessKey" className="govuk-accordion" data-module="govuk-accordion">
-          <div className="govuk-accordion__section">
-            <div className="govuk-accordion__section-header">
-              <h4 className="govuk-accordion__section-heading">
-                <span className="govuk-accordion__section-button" id="id" />
-              </h4>
-            </div>
-          </div>
+
+        <div
+          id={`caseSelected-${caseSelected.businessKey}`}
+          className="govuk-accordion"
+          data-module="govuk-accordion"
+        >
+          {caseSelected.processInstances.map((processInstance) => {
+            return (
+              <div className="govuk-accordion__section" key={processInstance.id}>
+                <div className="govuk-accordion__section-header">
+                  <h4 className="govuk-accordion__section-heading">
+                    <span
+                      className="govuk-accordion__section-button"
+                      id={`heading-${processInstance.id}`}
+                    >
+                      {processInstance.name}
+                    </span>
+                  </h4>
+                </div>
+                <div
+                  id={`accordion-with-summary-sections-content-${processInstance.id}`}
+                  className="govuk-accordion__section-content"
+                  aria-labelledby={`accordion-with-summary-sections-heading-${processInstance.id}`}
+                >
+                  <div className="govuk-grid-row govuk-!-margin-bottom-2">
+                    <div className="govuk-grid-column-full">
+                      <div className="govuk-grid-row">
+                        <div className="govuk-grid-column-one-half">
+                          <span className="govuk-caption-m">Status</span>
+                          <h3 className="govuk-heading-s">
+                            <span className="govuk-tag">
+                              {processInstance.endDate ? 'Completed' : 'Active'}
+                            </span>
+                          </h3>
+                        </div>
+                        <div className="govuk-grid-column-one-half">
+                          <span className="govuk-caption-m">Forms</span>
+                          <h3 className="govuk-heading-s">
+                            {processInstance.formReferences.length} completed
+                          </h3>
+                        </div>
+                        <div className="govuk-grid-column-one-half">
+                          <span className="govuk-caption-m">Start date</span>
+                          <h3 className="govuk-heading-s">
+                            {moment(processInstance.startDate).format('DD/MM/YYYY HH:mm')}
+                          </h3>
+                        </div>
+                        <div className="govuk-grid-column-one-half">
+                          <span className="govuk-caption-m">End date</span>
+
+                          <h3 className="govuk-heading-s">
+                            {processInstance.endDate
+                              ? moment(processInstance.endDate).format('DD/MM/YYYY HH:mm')
+                              : 'Active'}
+                          </h3>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                  {processInstance.formReferences.length !== 0 && (
+                    <FormDetails formReferences={processInstance.formReferences} />
+                  )}
+                  {processInstance.formReferences.length === 0 && (
+                    <h4 className="govuk-heading-s">No forms available</h4>
+                  )}
+                </div>
+              </div>
+            );
+          })}
         </div>
       </div>
     </>
   );
 };
+
+CaseHistory.propTypes = {
+  caseSelected: PropTypes.node.isRequired,
+};
+
 export default CaseHistory;

--- a/client/src/pages/cases/components/CaseHistory.jsx
+++ b/client/src/pages/cases/components/CaseHistory.jsx
@@ -6,7 +6,7 @@ import moment from 'moment';
 import { Accordion } from 'govuk-frontend';
 import FormDetails from './FormDetails';
 
-const CaseHistory = ({ caseSelected }) => {
+const CaseHistory = ({ businessKey, processInstances }) => {
   const { t } = useTranslation();
   const clearAccordionStorage = () => {
     _.forIn(window.sessionStorage, (value, key) => {
@@ -18,7 +18,7 @@ const CaseHistory = ({ caseSelected }) => {
 
   useEffect(() => {
     clearAccordionStorage();
-    new Accordion(document.getElementById(`caseSelected-${caseSelected.businessKey}`)).init();
+    new Accordion(document.getElementById(`caseSelected-${businessKey}`)).init();
   });
 
   return (
@@ -44,11 +44,11 @@ const CaseHistory = ({ caseSelected }) => {
         </div>
 
         <div
-          id={`caseSelected-${caseSelected.businessKey}`}
+          id={`caseSelected-${businessKey}`}
           className="govuk-accordion"
           data-module="govuk-accordion"
         >
-          {caseSelected.processInstances.map((processInstance) => {
+          {processInstances.map((processInstance) => {
             return (
               <div className="govuk-accordion__section" key={processInstance.id}>
                 <div className="govuk-accordion__section-header">
@@ -101,10 +101,9 @@ const CaseHistory = ({ caseSelected }) => {
                       </div>
                     </div>
                   </div>
-                  {processInstance.formReferences.length !== 0 && (
+                  {processInstance.formReferences.length ? (
                     <FormDetails formReferences={processInstance.formReferences} />
-                  )}
-                  {processInstance.formReferences.length === 0 && (
+                  ) : (
                     <h4 className="govuk-heading-s">No forms available</h4>
                   )}
                 </div>
@@ -118,7 +117,8 @@ const CaseHistory = ({ caseSelected }) => {
 };
 
 CaseHistory.propTypes = {
-  caseSelected: PropTypes.shape(PropTypes.object).isRequired,
+  businessKey: PropTypes.string.isRequired,
+  processInstances: PropTypes.arrayOf(PropTypes.object).isRequired,
 };
 
 export default CaseHistory;

--- a/client/src/pages/cases/components/CaseHistory.test.jsx
+++ b/client/src/pages/cases/components/CaseHistory.test.jsx
@@ -30,6 +30,9 @@ describe('Case History page', () => {
           { businessKey: 'businessKey3', processInstance: [] },
         ],
       },
+      _links: {
+        last: { href: 'url' },
+      },
     });
 
     mockAxios.onGet('/camunda/cases/businessKey1').reply(200, {

--- a/client/src/pages/cases/components/CaseHistory.test.jsx
+++ b/client/src/pages/cases/components/CaseHistory.test.jsx
@@ -1,0 +1,100 @@
+import React from 'react';
+import { render, waitFor, screen, fireEvent } from '@testing-library/react';
+import MockAdapter from 'axios-mock-adapter';
+import axios from 'axios';
+import CasePage from '../CasePage';
+import CaseResultsPanel from '../CasesResultsPanel';
+import CaseDetailsPanel from '../CaseDetailsPanel';
+import CaseHistory from './CaseHistory';
+
+describe('Case History page', () => {
+  const mockAxios = new MockAdapter(axios);
+
+  beforeEach(() => {
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+    mockAxios.reset();
+  });
+
+  it('shows Case History ', async () => {
+    mockAxios.onGet('/camunda/cases?query=keyword').reply(200, {
+      page: {
+        size: 20,
+        totalElements: 3,
+        totalPages: 1,
+        number: 0,
+      },
+      _embedded: {
+        cases: [
+          { businessKey: 'businessKey1', processInstance: [] },
+          { businessKey: 'businessKey2', processInstance: [] },
+          { businessKey: 'businessKey3', processInstance: [] },
+        ],
+      },
+    });
+
+    mockAxios.onGet('/camunda/cases/businessKey1').reply(200, {
+      businessKey: 'businessKey1',
+      processInstances: [
+        {
+          definitionId: 'intel-referral:3:85c1a0aa-34bb-11eb-924e-e61a6d54c1b3',
+          endDate: '2021-01-13T10:25:25.065+0000',
+          formReferences: [
+            {
+              formVersionId: '032a4350-3799-4c5b-9cda-c05034be0b30',
+              name: 'intelligenceReferral',
+              submissionDate: '2021-01-04T20:34:14.356Z',
+              submittedBy: 'line-manager@digital.homeoffice.gov.uk',
+              title: 'Intelligence Referral',
+            },
+          ],
+          id: 'e7e417c4-356b-11eb-b768-863d861ec96a',
+          key: 'intel-referral',
+          name: 'Submit Intelligence Referral',
+          openTasks: [],
+          startDate: '2020-12-03T13:31:53.319+0000',
+        },
+        {
+          definitionId: 'enhance-intel:2:c2d7a5b0-27f7-11eb-b6c2-922e59dab112',
+          endDate: '2021-01-13T10:25:24.993+0000',
+          formReferences: [],
+          id: 'e806bb0c-356b-11eb-b768-863d861ec96a',
+          key: 'enhance-intel',
+          name: 'Enhance intel',
+          openTasks: [],
+          startDate: '2020-12-03T13:31:53.546+0000',
+        },
+      ],
+    });
+
+    render(
+      <CasePage>
+        <CaseResultsPanel>
+          <CaseDetailsPanel>
+            <CaseHistory />
+          </CaseDetailsPanel>
+        </CaseResultsPanel>
+      </CasePage>
+    );
+    const input = screen.getByPlaceholderText('pages.cases.search-placeholder');
+    fireEvent.change(input, { target: { value: 'keyword' } });
+
+    await waitFor(() => {
+      expect(screen.getByText('businessKey1')).toBeTruthy();
+    });
+
+    const caseSelected = screen.getByText('businessKey1');
+    fireEvent.click(caseSelected);
+
+    await waitFor(() => {
+      expect(screen.getByText('Submit Intelligence Referral')).toBeTruthy();
+      expect(screen.getAllByText('Status')).toHaveLength(2);
+      expect(screen.getByText('1 completed')).toBeTruthy();
+      expect(screen.getAllByText('13/01/2021 10:25')).toHaveLength(2);
+      expect(screen.getByText('Enhance intel')).toBeTruthy();
+      expect(screen.getByText('0 completed')).toBeTruthy();
+      expect(screen.getByText('No forms available')).toBeTruthy();
+      expect(screen.getByText('Intelligence Referral')).toBeTruthy();
+      expect(screen.getByText('line-manager@digital.homeoffice.gov.uk')).toBeTruthy();
+    });
+  });
+});

--- a/client/src/pages/cases/components/CaseHistory.test.jsx
+++ b/client/src/pages/cases/components/CaseHistory.test.jsx
@@ -15,7 +15,7 @@ describe('Case History page', () => {
     mockAxios.reset();
   });
 
-  it('shows Case History ', async () => {
+  it('shows Case History when a case is selected', async () => {
     mockAxios.onGet('/camunda/cases?query=keyword').reply(200, {
       page: {
         size: 20,
@@ -66,6 +66,32 @@ describe('Case History page', () => {
       ],
     });
 
+    mockAxios.onGet('/camunda/cases/businessKey3').reply(200, {
+      businessKey: 'businessKey3',
+      processInstances: [
+        {
+          definitionId: 'intel-referral:3:85c1a0aa-34bb-11eb-924e-e61a6d54c1b3',
+          endDate: '2021-01-13T10:25:25.065+0000',
+          formReferences: [],
+          id: 'e7e417c4-356b-11eb-b768-863d861ec96a',
+          key: 'intel-referral',
+          name: 'TEST 2 NAME 1',
+          openTasks: [],
+          startDate: '2020-12-03T13:31:53.319+0000',
+        },
+        {
+          definitionId: 'enhance-intel:2:c2d7a5b0-27f7-11eb-b6c2-922e59dab112',
+          endDate: '2021-01-13T10:25:24.993+0000',
+          formReferences: [],
+          id: 'e806bb0c-356b-11eb-b768-863d861ec96a',
+          key: 'enhance-intel',
+          name: 'TEST 2 NAME 2',
+          openTasks: [],
+          startDate: '2020-12-03T13:31:53.546+0000',
+        },
+      ],
+    });
+
     render(
       <CasePage>
         <CaseResultsPanel>
@@ -75,16 +101,18 @@ describe('Case History page', () => {
         </CaseResultsPanel>
       </CasePage>
     );
+    // Search for a case by keyword
     const input = screen.getByPlaceholderText('pages.cases.search-placeholder');
     fireEvent.change(input, { target: { value: 'keyword' } });
 
     await waitFor(() => {
       expect(screen.getByText('businessKey1')).toBeTruthy();
     });
-
+    // Select case with businesskey1
     const caseSelected = screen.getByText('businessKey1');
     fireEvent.click(caseSelected);
 
+    // Correctly displays Case History in Case Details panel
     await waitFor(() => {
       expect(screen.getByText('Submit Intelligence Referral')).toBeTruthy();
       expect(screen.getAllByText('Status')).toHaveLength(2);
@@ -95,6 +123,15 @@ describe('Case History page', () => {
       expect(screen.getByText('No forms available')).toBeTruthy();
       expect(screen.getByText('Intelligence Referral')).toBeTruthy();
       expect(screen.getByText('line-manager@digital.homeoffice.gov.uk')).toBeTruthy();
+    });
+
+    // Changes Case Details panel when new case is selected and displays history correctly
+    const differentCase = screen.getByText('businessKey3');
+    fireEvent.click(differentCase);
+
+    await waitFor(() => {
+      expect(screen.getByText('TEST 2 NAME 1')).toBeTruthy();
+      expect(screen.getByText('TEST 2 NAME 2')).toBeTruthy();
     });
   });
 });

--- a/client/src/pages/cases/components/CaseIntro.jsx
+++ b/client/src/pages/cases/components/CaseIntro.jsx
@@ -1,13 +1,14 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { useTranslation } from 'react-i18next';
 
-const CaseIntro = () => {
+const CaseIntro = ({ businessKey }) => {
   const { t } = useTranslation();
 
   return (
     <>
       <div className="govuk-grid-column-one-half">
-        <h2 className="govuk-heading-m">Case</h2>
+        <h2 className="govuk-heading-m">{businessKey}</h2>
       </div>
       <div className="govuk-grid-column-one-half">
         <button
@@ -20,5 +21,9 @@ const CaseIntro = () => {
       </div>
     </>
   );
+};
+
+CaseIntro.propTypes = {
+  businessKey: PropTypes.string.isRequired,
 };
 export default CaseIntro;

--- a/client/src/pages/cases/components/FormDetails.jsx
+++ b/client/src/pages/cases/components/FormDetails.jsx
@@ -1,0 +1,71 @@
+import React, { useState, useEffect } from 'react';
+import { Details } from 'govuk-frontend';
+import PropTypes from 'prop-types';
+import moment from 'moment';
+
+const FormDetails = ({ formReferences }) => {
+  const [snapshot, setSnapshot] = useState({
+    formVersionId: null,
+    show: false,
+  });
+
+  useEffect(() => {
+    document.querySelectorAll('[data-module="govuk-details"]').forEach((element) => {
+      new Details(element).init();
+    });
+  });
+
+  return (
+    <>
+      {formReferences.map((form) => {
+        return (
+          <details key={form.formVersionId} className="govuk-details" data-module="govuk-details">
+            <summary className="govuk-details__summary">
+              <span className="govuk-details__summary-text">{form.title}</span>
+            </summary>
+            <div className="govuk-details__text">
+              <dl className="govuk-summary-list govuk-summary-list--no-border">
+                <div className="govuk-summary-list__row">
+                  <dt className="govuk-summary-list__key">Submitted by</dt>
+                  <dd className="govuk-summary-list__value">{form.submittedBy}</dd>
+                </div>
+                <div className="govuk-summary-list__row">
+                  <dt className="govuk-summary-list__key">Submitted on</dt>
+                  <dd className="govuk-summary-list__value">
+                    {moment(form.submissionDate).format('DD/MM/YYYY HH:mm')}
+                  </dd>
+                </div>
+                <div className="govuk-summary-list__row">
+                  <dt className="govuk-summary-list__key">
+                    <span className="govuk-tag">Latest</span>
+                  </dt>
+                  <dd className="govuk-summary-list__value">
+                    <button
+                      type="button"
+                      className="govuk-button"
+                      onClick={(e) => {
+                        e.preventDefault();
+                        setSnapshot({
+                          formVersionId: form.formVersionId,
+                          show: !snapshot.show,
+                        });
+                      }}
+                    >
+                      {snapshot.show ? 'Hide Details' : 'Show details'}
+                    </button>
+                  </dd>
+                </div>
+              </dl>
+            </div>
+          </details>
+        );
+      })}
+    </>
+  );
+};
+
+FormDetails.propTypes = {
+  formReferences: PropTypes.arrayOf(PropTypes.object).isRequired,
+};
+
+export default FormDetails;


### PR DESCRIPTION
**AC**
- replicate the behaviour from COP-v1 (cop-private-workflow-tasklist) for the cases page.

**Description**
- This branch adds the case search functionality - a user can search a business key or keyword and search results are displayed in left hand panel. 
- When the user selects a case link the details panel appears. So far, the only sections populated are the heading and the Case History section. 

**To test:** 
- Pull branch and run development server against the Dev environment (change proxy in package json). This is because the workflow-service latest build is still not working and you need to have the latest version of the API to get this to work. 
- Navigate to http://localhost:3000/cases and input a search. Results will appear on the left hand panel if there are hits. Select a case and the details panel will show with the Case history showing the process instances.
- "Show Details" form snapshot on Case History not implemented yet.
- npm run test to see tests for CasePage, CaseResults panel, Case History.

**NB:** 
- Cases API does not always bring back the correct "Number of cases found" - This is the same on V1.
- If a search has +20 hits the API paginates results. However, this doesn't seem to always work correctly, e.g. search keyword: abigail - it will say there are 40 results, over 2 pages, but "page 1" only has 6 results and the next has 14.
