### PR TITLE
COP-4634 Add form styling for disabled fields

### DIFF
--- a/client/src/pages/forms/FormPage.jsx
+++ b/client/src/pages/forms/FormPage.jsx
@@ -9,6 +9,7 @@ import { useAxios, useIsMounted } from '../../utils/hooks';
 import ApplicationSpinner from '../../components/ApplicationSpinner';
 import apiHooks from '../../components/form/hooks';
 import DisplayForm from '../../components/form/DisplayForm';
+import './Forms.scss';
 
 const FormPage = ({ formId }) => {
   const { submitForm } = apiHooks();

--- a/client/src/pages/forms/Forms.scss
+++ b/client/src/pages/forms/Forms.scss
@@ -1,0 +1,4 @@
+.govuk-input:disabled, .form-control:disabled, .form-control[readonly] {
+  background-color: #e9ecef;
+  opacity: 1;
+};


### PR DESCRIPTION
## AC
When fields are read only they should be clearly visible as such

## Updated
 - Replicated the styling used in v1
 - Made a Forms.scss as per pattern of having scss files for pages/components in their folders
 
## Notes
This is not part of GDS yet so must add to our app.