### PR TITLE
COP-4634 Add css for grey box on covid compliance form

### DIFF
--- a/client/src/pages/forms/Forms.scss
+++ b/client/src/pages/forms/Forms.scss
@@ -2,3 +2,16 @@
   background-color: #e9ecef;
   opacity: 1;
 };
+
+/* Custom styling for the covid-compliance-check grey box */
+.card-body {
+    padding: 1.25rem;
+};
+.card {
+    border: 1px solid rgba(0, 0, 0, 0.125);
+    border-radius: 0.25rem;
+    background-color: #f8f9fa;
+};
+.form-control {
+  background-color: #ffffff;
+}


### PR DESCRIPTION
## AC
Replicate v1 styling for v2 forms

## Updated
Added css to style the grey box to the Forms.scss as it is only used on the one form

## Notes
v1 used Bootstrap to style this, we do not use Bootstrap in v2 and this style isn't a GDS style so have implemented the simplest styling possible onto the FormBuilder classes that exist