### PR TITLE
COP-4634 add styling for case header width

### DIFF
--- a/client/src/pages/cases/CasesPage.scss
+++ b/client/src/pages/cases/CasesPage.scss
@@ -2,6 +2,8 @@
 @import '~govuk-frontend/govuk/settings/_colours-applied.scss';
 $govuk-card-border : govuk-colour('blue');
 
+$govuk-page-width: 1400px; 
+
 @import '~govuk-frontend/govuk/all';
 
 .search__input {


### PR DESCRIPTION
## AC
COP uses a 1400px header width, make cases use the same

## Updated
Added width setting to cases scss file

## Notes
The standard GDS width style is 900px but we use 1400px on COP. The DP GDS stylesheet keeps to the 900px width so we need to reset that in stylesheets to ensure every page keeps our 1400px width.