### PR TITLE
COP-2832 Show case attachments

### DIFF
--- a/client/public/locales/en-GB/translation.json
+++ b/client/public/locales/en-GB/translation.json
@@ -68,7 +68,15 @@
           "heading": "Case actions"
         },
         "case-attachments": {
-          "heading": "Case attachments"
+          "heading": "Case attachments",
+          "subheading": "View attachments",
+          "loading-attachments": "Loading attachments...",
+          "table": {
+            "header-1": "Name",
+            "header-2": "Uploaded on",
+            "header-3": "Uploaded by",
+            "no-attachments": "No attachments associated with case"
+          }
         },
         "case-history": {
           "heading": "Case history",

--- a/client/src/pages/cases/CaseDetailsPanel.jsx
+++ b/client/src/pages/cases/CaseDetailsPanel.jsx
@@ -19,7 +19,7 @@ const CaseDetailsPanel = ({ businessKey, processInstances }) => {
         <CaseHistory processInstances={processInstances} businessKey={businessKey} />
       </div>
       <div className="govuk-grid-row govuk-card govuk-!-margin-top-4">
-        <CaseAttachments />
+        <CaseAttachments businessKey={businessKey} />
       </div>
       <div className="govuk-grid-row govuk-card govuk-!-margin-top-4">
         <CaseMetrics />

--- a/client/src/pages/cases/components/CaseAttachments.jsx
+++ b/client/src/pages/cases/components/CaseAttachments.jsx
@@ -1,17 +1,126 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
+import PropTypes from 'prop-types';
+import axios from 'axios';
+import { useKeycloak } from '@react-keycloak/web';
 import { useTranslation } from 'react-i18next';
+import { useAxios } from '../../../utils/hooks';
+import FileService from '../../../utils/FileService';
 
-const CaseAttachments = () => {
+const CaseAttachments = ({ businessKey }) => {
   const { t } = useTranslation();
+  const axiosInstance = useAxios();
+  const [keycloak] = useKeycloak();
+  const [caseAttachments, setCaseAttachments] = useState({
+    fetching: true,
+    data: [],
+  });
+  const fileService = new FileService(keycloak);
 
+  const handleDownload = (e, attachment) => {
+    e.preventDefault();
+    const { url, submittedFilename } = attachment;
+    fileService.downloadFile({
+      url,
+      originalName: submittedFilename,
+    });
+  };
+
+  useEffect(() => {
+    const source = axios.CancelToken.source();
+
+    const fetchCaseAttachments = async () => {
+      if (axiosInstance) {
+        try {
+          const { data } = await axiosInstance.get(`/files/files/${businessKey}`, {
+            cancelToken: source.token,
+          });
+          setCaseAttachments({
+            fetching: false,
+            data,
+          });
+        } catch {
+          setCaseAttachments({
+            fetching: false,
+            data: [],
+          });
+        }
+      }
+    };
+
+    fetchCaseAttachments();
+    return () => {
+      source.cancel('cancelling request');
+    };
+  }, [axiosInstance]);
+
+  const { data, fetching } = caseAttachments;
+  if (fetching) {
+    return (
+      <div className="govuk-grid-column-full">
+        <h3 className="govuk-heading-m">Loading attachments...</h3>
+      </div>
+    );
+  }
   return (
     <>
       <div className="govuk-grid-column-full">
         <h3 className="govuk-heading-m">
           {t('pages.cases.details-panel.case-attachments.heading')}
         </h3>
+        <details className="govuk-details" data-module="govuk-details">
+          <summary className="govuk-details__summary">
+            <span className="govuk-details__summary-text">View attachments</span>
+          </summary>
+          <table className="govuk-table">
+            <thead className="govuk-table__head">
+              <tr className="govuk-table__row">
+                <th scope="col" className="govuk-table__header">
+                  Name
+                </th>
+                <th scope="col" className="govuk-table__header">
+                  Uploaded on
+                </th>
+                <th scope="col" className="govuk-table__header">
+                  Uploaded by
+                </th>
+              </tr>
+            </thead>
+            <tbody className="govuk-table__body">
+              {data.length === 0 ? (
+                <h3 className="govuk-heading-s govuk-!-margin-top-4">
+                  No attachments associated with case
+                </h3>
+              ) : (
+                data.map((attachment) => {
+                  const { url, submittedFilename, submittedDateTime, submittedEmail } = attachment;
+                  return (
+                    <tr className="govuk-table__row" key={url}>
+                      <th scope="row" className="govuk-table__header">
+                        {/* eslint-disable-next-line */}
+                        <a
+                          className="govuk-link"
+                          href="#"
+                          onClick={(e) => handleDownload(e, attachment)}
+                        >
+                          {submittedFilename}
+                        </a>
+                      </th>
+                      <td className="govuk-table__cell">{submittedDateTime}</td>
+                      <td className="govuk-table__cell">{submittedEmail}</td>
+                    </tr>
+                  );
+                })
+              )}
+            </tbody>
+          </table>
+        </details>
       </div>
     </>
   );
 };
+
+CaseAttachments.propTypes = {
+  businessKey: PropTypes.string.isRequired,
+};
+
 export default CaseAttachments;

--- a/client/src/pages/cases/components/CaseAttachments.jsx
+++ b/client/src/pages/cases/components/CaseAttachments.jsx
@@ -91,9 +91,11 @@ const CaseAttachments = ({ businessKey }) => {
             </thead>
             <tbody className="govuk-table__body">
               {data.length === 0 ? (
-                <h3 className="govuk-heading-s govuk-!-margin-top-4">
-                  {t('pages.cases.details-panel.case-attachments.table.no-attachments')}
-                </h3>
+                <tr className="govuk-table__row govuk-heading-s govuk-!-margin-top-4">
+                  <th scope="row" className="govuk-table__header">
+                    {t('pages.cases.details-panel.case-attachments.table.no-attachments')}
+                  </th>
+                </tr>
               ) : (
                 data.map((attachment) => {
                   const { url, submittedFilename, submittedDateTime, submittedEmail } = attachment;

--- a/client/src/pages/cases/components/CaseAttachments.jsx
+++ b/client/src/pages/cases/components/CaseAttachments.jsx
@@ -57,7 +57,9 @@ const CaseAttachments = ({ businessKey }) => {
   if (fetching) {
     return (
       <div className="govuk-grid-column-full">
-        <h3 className="govuk-heading-m">Loading attachments...</h3>
+        <h3 className="govuk-heading-m">
+          {t('pages.cases.details-panel.case-attachments.loading-attachments')}
+        </h3>
       </div>
     );
   }
@@ -69,26 +71,28 @@ const CaseAttachments = ({ businessKey }) => {
         </h3>
         <details className="govuk-details" data-module="govuk-details">
           <summary className="govuk-details__summary">
-            <span className="govuk-details__summary-text">View attachments</span>
+            <span className="govuk-details__summary-text">
+              {t('pages.cases.details-panel.case-attachments.subheading')}
+            </span>
           </summary>
           <table className="govuk-table">
             <thead className="govuk-table__head">
               <tr className="govuk-table__row">
                 <th scope="col" className="govuk-table__header">
-                  Name
+                  {t('pages.cases.details-panel.case-attachments.table.header-1')}
                 </th>
                 <th scope="col" className="govuk-table__header">
-                  Uploaded on
+                  {t('pages.cases.details-panel.case-attachments.table.header-2')}
                 </th>
                 <th scope="col" className="govuk-table__header">
-                  Uploaded by
+                  {t('pages.cases.details-panel.case-attachments.table.header-3')}
                 </th>
               </tr>
             </thead>
             <tbody className="govuk-table__body">
               {data.length === 0 ? (
                 <h3 className="govuk-heading-s govuk-!-margin-top-4">
-                  No attachments associated with case
+                  {t('pages.cases.details-panel.case-attachments.table.no-attachments')}
                 </h3>
               ) : (
                 data.map((attachment) => {

--- a/client/src/pages/cases/components/CaseAttachments.test.jsx
+++ b/client/src/pages/cases/components/CaseAttachments.test.jsx
@@ -1,0 +1,90 @@
+import React from 'react';
+import { screen, render, waitFor, fireEvent } from '@testing-library/react';
+import { shallow } from 'enzyme';
+import MockAdapter from 'axios-mock-adapter';
+import axios from 'axios';
+import CaseAttachments from './CaseAttachments';
+import FileService from '../../../utils/FileService';
+
+jest.mock('../../../utils/FileService');
+
+describe('CaseAttachments', () => {
+  const mockAxios = new MockAdapter(axios);
+  const testBusinessKey = 'BUSINESS-KEY';
+  const mockData = [];
+
+  for (let i = 0; i < 3; i += 1) {
+    mockData.push({
+      submittedFilename: `test-file${i}.pdf`,
+      submittedEmail: 'officer@homeoffice.gov.uk',
+      submittedDateTime: '2020-01-27 12:21:23',
+      url: `test-url${i}`,
+    });
+  }
+
+  beforeEach(() => {
+    FileService.mockClear();
+    // eslint-disable-next-line no-console
+    console.error = jest.fn();
+    mockAxios.reset();
+  });
+
+  afterAll(() => {
+    FileService.mockClear();
+  });
+
+  it('should render without error', () => {
+    shallow(<CaseAttachments businessKey={testBusinessKey} />);
+  });
+
+  it('should render loading if file service has not responded', async () => {
+    mockAxios.onGet(`/files/files/${testBusinessKey}`).reply(200, []);
+
+    render(<CaseAttachments businessKey={testBusinessKey} />);
+
+    await waitFor(() => {
+      expect(
+        screen.queryByText('pages.cases.details-panel.case-attachments.loading-attachments')
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('should render case attachments without error', async () => {
+    mockAxios.onGet(`/files/files/${testBusinessKey}`).reply(200, mockData);
+
+    await waitFor(() => render(<CaseAttachments businessKey={testBusinessKey} />));
+
+    mockData.forEach((element) => {
+      expect(screen.queryByText(element.submittedFilename)).toBeInTheDocument();
+    });
+  });
+
+  it('should be able to download case attachment without error', async () => {
+    mockAxios.onGet(`/files/files/${testBusinessKey}`).reply(200, mockData);
+
+    await waitFor(() => render(<CaseAttachments businessKey={testBusinessKey} />));
+
+    fireEvent.click(screen.getByText('test-file0.pdf'));
+
+    /*
+     * FileService.mock.instances.length - 1 refers to the most recent instance of the
+     * FileService class - which is in this test at the time of the test executing
+     */
+    expect(
+      FileService.mock.instances[FileService.mock.instances.length - 1].downloadFile
+    ).toHaveBeenCalledWith({
+      url: 'test-url0',
+      originalName: 'test-file0.pdf',
+    });
+  });
+
+  it('should handle no case attachments existing for case gracefully', async () => {
+    mockAxios.onGet(`/files/files/${testBusinessKey}`).reply(500);
+
+    await waitFor(() => render(<CaseAttachments businessKey={testBusinessKey} />));
+
+    expect(
+      screen.queryByText('pages.cases.details-panel.case-attachments.table.no-attachments')
+    ).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
### AC
User should be able to see case attachments and successfully download them if present

### Updated
- Added functionality to `CaseAttachments` component
- Added relevant tests for `CaseAttachments` component
- Moved content out of `CaseAttachments` into `translation.json`

### To test
- Pull and run cop locally setting the `proxy` in `package.json` to cop-ui dev

SCENARIO 1: 
ON COP-UI DEV:
- Submit `Record border event` form opting to attach file
- Move through to attachment form and attach file with valid file type (keep note of the file you attached)
- Submit form and make note of the business key

ON LOCAL:

- Navigate to cases page and search business key
- Select business key from list
- Scroll down to Case Attachments and click on `View attachments`
- *You should see the file you attached appear in the list*
- Click on the file name
- *Your file should download successfully*

SCENARIO 2: 
ON COP-UI DEV

- Submit `Record border event` form opting NOT to attach file
- Submit form and make note of the business key

ON LOCAL:
- Navigate to cases page and search business key
- Select business key from list
- Scroll down to Case Attachments and click on `View attachments`
- *You should see `No attachments associated with case` appear in the table*
