### PR TITLE
COP-5132 Add comments hasFormChanged state

### DIFF
--- a/client/src/components/form/DisplayForm.jsx
+++ b/client/src/components/form/DisplayForm.jsx
@@ -27,6 +27,7 @@ const DisplayForm = ({
   submitting,
 }) => {
   const [errorAlert, setErrorAlert] = useState();
+  const [hasFormChanged, setHasFormChanged] = useState(false);
   const formRef = useRef();
   const host = `${window.location.protocol}//${window.location.hostname}${
     window.location.port ? `:${window.location.port}` : ''
@@ -237,6 +238,8 @@ const DisplayForm = ({
           handleOnSubmit(submissionData);
         }}
         onChange={(data) => {
+          // If we remove this set state the context does not load correctly
+          setHasFormChanged(!hasFormChanged);
           if (formRef.current) {
             validate(formRef.current.formio, data);
           }


### PR DESCRIPTION
### AC 
All forms should have access to context variables without error

### Updated
- Added `hasFormChanged ` state to form component in order for context to be available to the form

### To test
- Pull and run cop locally proxying to dev
- Login
- Open network tab in dev tools

SCENARIO 1:
- Submit first part of `Record border event`
- Select the `submit-form` in the network tab
- Look at the `Request payload`
- *You should not see `processContext` and `taskContext` in the payload*
- *You should see other context objects in the payload*

SCENARIO 2:
- Select `Submit Intelligence referral` form
- *On the first question, you SHOULD see the `What type of information do you want to report?` question*
- Submit first part of `Submit Intelligence referral`
- Select the second `submit-form` in the network tab
- Look at the `Request payload`
- *You should not see `processContext` and `taskContext` in the payload*
- *You should see other context objects in the payload*