### PR TITLE
COP-3935 Remove context objects on form submission

### DIFF
--- a/client/src/components/form/DisplayForm.jsx
+++ b/client/src/components/form/DisplayForm.jsx
@@ -280,9 +280,11 @@ const DisplayForm = ({
                 submissionDate: new Date(),
                 submittedBy: keycloak.tokenParsed.email,
               };
-              // processContext and taskContext not need in request payload
+              // processContext, taskContext, keycloakContext and staffDetailsDataContext not needed in request payload
               delete submissionData.data.processContext;
               delete submissionData.data.taskContext;
+              delete submissionData.data.keycloakContext;
+              delete submissionData.data.staffDetailsDataContext;
               /* eslint-enable no-param-reassign, no-shadow */
               next();
             },


### PR DESCRIPTION
### AC
Forms should not add `keycloakContext` and `staffDetailsDataContext` to the request payload

### Updated
- Add test for context removal in `DisplayForm`

### Notes
- For further evidence of the context objects not existing in submission, cockpit can also be used to check the payload from each form that exists in camunda

### To test
- Pull and run cop locally
- Login 
- Open network tab in dev tools
- Submit a form (a form that creates a task and does not end straight away i.e. intel ref, record border event )
- *Your form should submit successfully*
- Click on the `submit-form` request in the network tab
- Inspect the `Request Payload`
- *You should NOT see `keycloakContext` and `staffDetailsDataContext` in the payload*
