### PR TITLE
COP-5249 Enable case loading when URL has caseId

### DIFF
--- a/client/src/pages/cases/CasePage.jsx
+++ b/client/src/pages/cases/CasePage.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { useHistory } from 'react-navi';
 import { useTranslation } from 'react-i18next';
 import { useMatomo } from '@datapunt/matomo-tracker-react';
 import { debounce } from 'lodash';
@@ -16,6 +17,7 @@ const CasePage = (caseId) => {
   }, []);
 
   const axiosInstance = useAxios();
+  const history = useHistory();
   const [caseSearchResults, setCaseSearchResults] = useState(null);
   const [caseArray, setCaseArray] = useState(null);
   const [searching, setSearching] = useState(false);
@@ -72,6 +74,7 @@ const CasePage = (caseId) => {
       setProcessInstances([]);
     } finally {
       setCaseLoading(false);
+      history.push(businessKey);
     }
   };
 
@@ -79,7 +82,7 @@ const CasePage = (caseId) => {
     if (axiosInstance) {
       getCaseDetails(caseId.caseId);
     }
-  }, [caseId, axiosInstance]);
+  }, [axiosInstance]);
 
   return (
     <>

--- a/client/src/pages/cases/CasePage.jsx
+++ b/client/src/pages/cases/CasePage.jsx
@@ -3,12 +3,13 @@ import { useHistory } from 'react-navi';
 import { useTranslation } from 'react-i18next';
 import { useMatomo } from '@datapunt/matomo-tracker-react';
 import { debounce } from 'lodash';
+import PropTypes from 'prop-types';
 import { useAxios } from '../../utils/hooks';
 import CasesResultsPanel from './CasesResultsPanel';
 import CaseDetailsPanel from './CaseDetailsPanel';
 import './CasesPage.scss';
 
-const CasePage = (caseId) => {
+const CasePage = ({ caseId }) => {
   const { t } = useTranslation();
   const { trackPageView } = useMatomo();
 
@@ -82,12 +83,8 @@ const CasePage = (caseId) => {
     // This useEffect function should only run getCaseDetails
     // when a user enters a URL that contains a caseId (either manually, or by clicking a link to it)
     // or when a user clicks 'back' in their browser and the URL they go back to is a case URL with a caseId
-    if (
-      axiosInstance &&
-      (!caseSelected || caseId.caseId !== caseSelected.businessKey) &&
-      caseId.caseId
-    ) {
-      getCaseDetails(caseId.caseId);
+    if (axiosInstance && (!caseSelected || caseId !== caseSelected.businessKey) && caseId) {
+      getCaseDetails(caseId);
     }
   }, [axiosInstance, caseId]);
 
@@ -143,6 +140,14 @@ const CasePage = (caseId) => {
       </div>
     </>
   );
+};
+
+CasePage.defaultProps = {
+  caseId: null,
+};
+
+CasePage.propTypes = {
+  caseId: PropTypes.string,
 };
 
 export default CasePage;

--- a/client/src/pages/cases/CasePage.jsx
+++ b/client/src/pages/cases/CasePage.jsx
@@ -7,7 +7,7 @@ import CasesResultsPanel from './CasesResultsPanel';
 import CaseDetailsPanel from './CaseDetailsPanel';
 import './CasesPage.scss';
 
-const CasePage = () => {
+const CasePage = (caseId) => {
   const { t } = useTranslation();
   const { trackPageView } = useMatomo();
 
@@ -74,6 +74,12 @@ const CasePage = () => {
       setCaseLoading(false);
     }
   };
+
+  useEffect(() => {
+    if (axiosInstance) {
+      getCaseDetails(caseId.caseId);
+    }
+  }, [caseId, axiosInstance]);
 
   return (
     <>

--- a/client/src/pages/cases/CasePage.jsx
+++ b/client/src/pages/cases/CasePage.jsx
@@ -118,7 +118,7 @@ const CasePage = ({ caseId }) => {
       <div className="govuk-grid-row">
         <div className="govuk-grid-column-one-quarter">
           {searching && <h4 className="govuk-heading-s">{t('pages.cases.search-message')}</h4>}
-          {!searching && (
+          {!searching && (caseSearchResults || caseSelected) && (
             <CasesResultsPanel
               totalElements={!caseSearchResults ? null : caseSearchResults.page.totalElements}
               caseArray={caseArray}

--- a/client/src/pages/cases/CasePage.jsx
+++ b/client/src/pages/cases/CasePage.jsx
@@ -69,20 +69,24 @@ const CasePage = (caseId) => {
       const resp = await axiosInstance.get(`/camunda/cases/${businessKey}`);
       setCaseSelected(resp.data);
       setProcessInstances(resp.data.processInstances);
+      history.push(businessKey);
     } catch (err) {
       setCaseSelected(null);
       setProcessInstances([]);
     } finally {
       setCaseLoading(false);
-      history.push(businessKey);
     }
   };
 
   useEffect(() => {
-    if (axiosInstance) {
+    // When user loads page with a caseId in the route we want to load that case
+    // If user then enters a search and clicks a businessKey, we do not want to run this useEffect
+    // So we check caseId against caseSelected.businessKey and if it's a match we do not run this function
+    // Because we want to run this useEffect when the user clicks 'back' in their browser, if caseId does not match caseSelected.businessKey, then we do run this function
+    if (axiosInstance && (!caseSelected || caseId.caseId !== caseSelected.businessKey)) {
       getCaseDetails(caseId.caseId);
     }
-  }, [axiosInstance]);
+  }, [axiosInstance, caseId]);
 
   return (
     <>

--- a/client/src/pages/cases/CasePage.jsx
+++ b/client/src/pages/cases/CasePage.jsx
@@ -69,7 +69,7 @@ const CasePage = (caseId) => {
       const resp = await axiosInstance.get(`/camunda/cases/${businessKey}`);
       setCaseSelected(resp.data);
       setProcessInstances(resp.data.processInstances);
-      history.push(businessKey);
+      history.push(`/cases/${businessKey}`);
     } catch (err) {
       setCaseSelected(null);
       setProcessInstances([]);
@@ -79,11 +79,14 @@ const CasePage = (caseId) => {
   };
 
   useEffect(() => {
-    // When user loads page with a caseId in the route we want to load that case
-    // If user then enters a search and clicks a businessKey, we do not want to run this useEffect
-    // So we check caseId against caseSelected.businessKey and if it's a match we do not run this function
-    // Because we want to run this useEffect when the user clicks 'back' in their browser, if caseId does not match caseSelected.businessKey, then we do run this function
-    if (axiosInstance && (!caseSelected || caseId.caseId !== caseSelected.businessKey)) {
+    // This useEffect function should only run getCaseDetails
+    // when a user enters a URL that contains a caseId (either manually, or by clicking a link to it)
+    // or when a user clicks 'back' in their browser and the URL they go back to is a case URL with a caseId
+    if (
+      axiosInstance &&
+      (!caseSelected || caseId.caseId !== caseSelected.businessKey) &&
+      caseId.caseId
+    ) {
       getCaseDetails(caseId.caseId);
     }
   }, [axiosInstance, caseId]);

--- a/client/src/pages/cases/CasePage.jsx
+++ b/client/src/pages/cases/CasePage.jsx
@@ -118,9 +118,9 @@ const CasePage = (caseId) => {
       <div className="govuk-grid-row">
         <div className="govuk-grid-column-one-quarter">
           {searching && <h4 className="govuk-heading-s">{t('pages.cases.search-message')}</h4>}
-          {!searching && caseSearchResults && (
+          {!searching && (
             <CasesResultsPanel
-              totalElements={caseSearchResults.page.totalElements}
+              totalElements={!caseSearchResults ? null : caseSearchResults.page.totalElements}
               caseArray={caseArray}
               getCaseDetails={getCaseDetails}
               loadMoreCases={loadMoreCases}

--- a/client/src/pages/cases/CasePage.test.jsx
+++ b/client/src/pages/cases/CasePage.test.jsx
@@ -15,8 +15,12 @@ describe('CasePage', () => {
     mockAxios.reset();
   });
 
-  it('should render without crashing', () => {
+  it('should render without crashing when there is a caseId prop', () => {
     shallow(<CasePage caseId="id" />);
+  });
+
+  it('should render without crashing when there is NO caseId prop', () => {
+    shallow(<CasePage />);
   });
 
   it('should render results of case search when applicable', async () => {

--- a/client/src/pages/cases/CasesResultsPanel.jsx
+++ b/client/src/pages/cases/CasesResultsPanel.jsx
@@ -48,10 +48,11 @@ const CaseResultsPanel = ({ totalElements, caseArray, getCaseDetails, loadMoreCa
 
 CaseResultsPanel.defaultProps = {
   caseArray: null,
+  totalElements: null,
 };
 
 CaseResultsPanel.propTypes = {
-  totalElements: PropTypes.number.isRequired,
+  totalElements: PropTypes.number,
   caseArray: PropTypes.arrayOf(PropTypes.object),
   getCaseDetails: PropTypes.func.isRequired,
   loadMoreCases: PropTypes.func.isRequired,

--- a/client/src/pages/cases/components/FormDetails.jsx
+++ b/client/src/pages/cases/components/FormDetails.jsx
@@ -70,7 +70,7 @@ const FormDetails = ({ formReferences, businessKey }) => {
     <>
       {formReferences.map((formInstance, index) => {
         return (
-          <>
+          <React.Fragment key={formInstance.formVersionId}>
             <details
               key={formInstance.formVersionId}
               className="govuk-details"
@@ -147,7 +147,7 @@ const FormDetails = ({ formReferences, businessKey }) => {
               </div>
             </details>
             {index < formReferences.length - 1 ? <hr className="form-seperator" /> : null}
-          </>
+          </React.Fragment>
         );
       })}
     </>

--- a/client/src/setupTests.js
+++ b/client/src/setupTests.js
@@ -15,6 +15,7 @@ export const mockLogout = jest.fn();
 export const mockLogin = jest.fn();
 export const mockGoBack = jest.fn();
 export const mockExtractState = jest.fn();
+export const mockHistoryPush = jest.fn();
 
 jest.mock('@react-keycloak/web', () => ({
   KeycloakProvider: ({ children }) => children,
@@ -55,6 +56,9 @@ jest.mock('react-navi', () => ({
     extractState: mockExtractState,
     navigate: mockNavigate,
     goBack: mockGoBack,
+  })),
+  useHistory: jest.fn(() => ({
+    push: mockHistoryPush,
   })),
   NotFoundBoundary: ({ children }) => children,
   Link: ({ children }) => children,


### PR DESCRIPTION
## AC

When a user clicks a link to a case from a task page make the case open

## Notes

- the url will have the case ID in it so achieving the AC also achieves the link click from an email and from a direct paste

## Updated

- added a call to the getCaseDetails function on load when there is a new caseId (businessKey) in the url

## To test

- go to your or team `tasklist`
- click on a task
- click on the businessKey link at the top of the page
> you should be taken to the Cases page, with the case loaded for the businessKey you clicked on

- search for a case
> you should no longer see the case that was on the page 
> you should see search results (make sure you've searched for something you know will return results)

- click on a search result
> you should see the Case for this businessKey