### PR TITLE
COP-3840 Add empty object for existingSubmission

### DIFF
--- a/client/src/pages/forms/FormPage.jsx
+++ b/client/src/pages/forms/FormPage.jsx
@@ -118,6 +118,7 @@ const FormPage = ({ formId }) => {
         interpolateContext={{
           businessKey: businessKeyComponent ? businessKeyComponent.defaultValue : null,
         }}
+        existingSubmission={{}}
         handleOnSubmit={(data) => {
           setSubmitting(true);
           submitForm({


### PR DESCRIPTION
## AC

Some forms seem to be caching data after submit, and then pre-filling the form with that -- make it stop.

## Notes

It seems to be linked to the `existingSubmission` prop on `DisplayForm`.
Within that we have a `<Form>` component that we pass `submission` to -> and that `submission` uses `existingSubmission` to create it's data.

If you pass nothing to `submission` then FormIO seems to have stored previous answers in a cache/context/state/something (not sure where it's storing it) & populates the form with that.

However, if you pass an empty object then it respects the empty object and does not populate stale data.

For Tasks, we were passing `formSubmission` as `existingSubmission` because there were details to be passed
For Forms, we weren't passing anything which seems to be the issue.

## Updated

Added an `existingSubmission` prop to the `<DisplayForm>` component on `<FormPage>`

## To Test

- go to Covid Compliance Checks form
- tick submit another
- click submit
> a new version of the form should load with only date & your location data prefilled (from Context)

- go to Edit Profile
> Your details should still be prefilled

- go to a Task (any type)
> You should be able to submit it 

- go to a Form (any type)
> you should be able to submit it