### PR TITLE
COP-4924 Form not found throwing 404 instead of page not found message

### DIFF
--- a/client/src/components/alert/ApiErrorAlert.jsx
+++ b/client/src/components/alert/ApiErrorAlert.jsx
@@ -1,25 +1,38 @@
-import React from 'react';
+import React, { useContext, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import PropType from 'prop-types';
 import { v4 as uuidv4 } from 'uuid';
 import config from 'react-global-configuration';
+import { useHistory } from 'react-navi';
+import NotFound from '../NotFound';
+import { AlertContext } from '../../utils/AlertContext';
 
 const ApiErrorAlert = ({ errors }) => {
   const { t } = useTranslation();
+  const history = useHistory();
+  const { setAlertContext } = useContext(AlertContext);
+
+  useEffect(() => {
+    const unlisten = history.listen(() => {
+      setAlertContext(null);
+    });
+    return () => {
+      if (unlisten) {
+        unlisten();
+      }
+    };
+  }, []);
 
   if (errors.length === 0) {
     return null;
   }
 
   const buildMessage = (err) => {
-    const { status, message } = err;
+    const { status } = err;
     let errorMessage;
     switch (status) {
       case 409:
         errorMessage = t('error.api.409');
-        break;
-      case 404:
-        errorMessage = `${message}`;
         break;
       case 401:
       case 403:
@@ -37,6 +50,10 @@ const ApiErrorAlert = ({ errors }) => {
       </li>
     );
   };
+
+  if (errors.find((error) => error.status === 404)) {
+    return <NotFound />;
+  }
 
   return (
     <div

--- a/client/src/components/alert/ApiErrorAlert.test.jsx
+++ b/client/src/components/alert/ApiErrorAlert.test.jsx
@@ -9,12 +9,11 @@ describe('ApiErrorAlert', () => {
   });
 
   it.each`
-    status | message                  | path
-    ${409} | ${''}                    | ${'/api/test'}
-    ${404} | ${'data does not exist'} | ${'/api/test'}
-    ${401} | ${'unauthorized'}        | ${'/api/test'}
-    ${400} | ${'bad data'}            | ${'/api/test'}
-    ${500} | ${'internal'}            | ${'/api/test'}
+    status | message           | path
+    ${409} | ${''}             | ${'/api/test'}
+    ${401} | ${'unauthorized'} | ${'/api/test'}
+    ${400} | ${'bad data'}     | ${'/api/test'}
+    ${500} | ${'internal'}     | ${'/api/test'}
   `('error displayed for $status', async ({ status, message, path }) => {
     const wrapper = shallow(
       <ApiErrorAlert
@@ -29,4 +28,5 @@ describe('ApiErrorAlert', () => {
     );
     expect(wrapper.find('.govuk-error-summary__title').exists()).toBe(true);
   });
+  // 404 check
 });

--- a/client/src/components/alert/ApiErrorAlert.test.jsx
+++ b/client/src/components/alert/ApiErrorAlert.test.jsx
@@ -1,8 +1,15 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { shallow, mount } from 'enzyme';
 import ApiErrorAlert from './ApiErrorAlert';
+import NotFound from '../NotFound';
+import Layout from '../layout';
+import { mockHistoryListen } from '../../setupTests';
 
 describe('ApiErrorAlert', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('renders nothing if no errors', () => {
     const wrapper = shallow(<ApiErrorAlert errors={[]} />);
     expect(wrapper.find('div').length).toBe(0);
@@ -28,5 +35,49 @@ describe('ApiErrorAlert', () => {
     );
     expect(wrapper.find('.govuk-error-summary__title').exists()).toBe(true);
   });
-  // 404 check
+
+  it('should render "Page not found"  if 404 is returned', () => {
+    const wrapper = mount(
+      <ApiErrorAlert
+        errors={[
+          {
+            status: 404,
+            message: 'Not found',
+            path: '/api/test',
+          },
+        ]}
+      />
+    );
+
+    expect(wrapper.find(NotFound).exists()).toBe(true);
+  });
+
+  it.each`
+    status | message           | path
+    ${409} | ${''}             | ${'/api/test'}
+    ${404} | ${'not found'}    | ${'/api/test'}
+    ${401} | ${'unauthorized'} | ${'/api/test'}
+    ${400} | ${'bad data'}     | ${'/api/test'}
+    ${500} | ${'internal'}     | ${'/api/test'}
+  `('error removed for $status', async ({ status, message, path }) => {
+    const wrapper = mount(
+      <Layout>
+        <ApiErrorAlert
+          errors={[
+            {
+              status,
+              message,
+              path,
+            },
+          ]}
+        />
+      </Layout>
+    );
+
+    wrapper.find('a[id="home"]').simulate('click');
+
+    expect(mockHistoryListen).toHaveBeenCalled();
+
+    mockHistoryListen.mockClear();
+  });
 });

--- a/client/src/pages/cases/CasePage.test.jsx
+++ b/client/src/pages/cases/CasePage.test.jsx
@@ -88,6 +88,7 @@ describe('CasePage', () => {
         <CasePage />
       </AlertContextProvider>
     );
+
     const input = screen.getByPlaceholderText('pages.cases.search-placeholder');
 
     fireEvent.change(input, { target: { value: 'keywordError' } });

--- a/client/src/setupTests.js
+++ b/client/src/setupTests.js
@@ -16,6 +16,7 @@ export const mockLogin = jest.fn();
 export const mockGoBack = jest.fn();
 export const mockExtractState = jest.fn();
 export const mockHistoryPush = jest.fn();
+export const mockHistoryListen = jest.fn();
 
 jest.mock('@react-keycloak/web', () => ({
   KeycloakProvider: ({ children }) => children,
@@ -59,7 +60,7 @@ jest.mock('react-navi', () => ({
   })),
   useHistory: jest.fn(() => ({
     push: mockHistoryPush,
-    listen: jest.fn(),
+    listen: mockHistoryListen,
   })),
   NotFoundBoundary: ({ children }) => children,
   Link: ({ children }) => children,

--- a/client/src/setupTests.js
+++ b/client/src/setupTests.js
@@ -59,6 +59,7 @@ jest.mock('react-navi', () => ({
   })),
   useHistory: jest.fn(() => ({
     push: mockHistoryPush,
+    listen: jest.fn(),
   })),
   NotFoundBoundary: ({ children }) => children,
   Link: ({ children }) => children,


### PR DESCRIPTION
### AC
When the user tries to access a form that does not exist, they should receive a `Page not found` error - as seen in v1. When the user navigates away from the erroring page, the error should NOT persist

### Updates
- Removed 404 from switch statement in `ApiErrorAlert` and handle rendering `NotFound` independent of the other API errors
- Added history listener into `ApiErrorAlert` that fires when the url changes which in turn sets the `AlertContext` to null
- When `ApiErrorAlert` component unmounts the url listener is removed as it is not required when no errors are present
- Altered and added assertions to `ApiErrorAlert` to account for changes

### To test
- Pull and run cop locally pointing the proxy to the dev environment
- Login
- Navigate to the form list
- Add a random string to the end of the url e.g `forms/<RANDOM WORD HERE>` and hit enter
- *You should see a 'page not found' component rendered*
- Click the `Central Operations Platform` in the top left hand corner of the screen
- *You should be taken to the dashboard*
- *You should NOT see the error alert persist*
- Repeat this process before the next step but when the error is first displayed, click other navigational links - each time the error should be removed from the screen
- Navigate to form list
- Submit `Hot Debrief` form
- *You should be taken to the dashboard*
- *You should see the successful submission alert persist*