### PR TITLE
COP-3793 Remove existingSubmission as it has become redundant

### DIFF
--- a/client/src/components/form/DisplayForm.jsx
+++ b/client/src/components/form/DisplayForm.jsx
@@ -18,14 +18,7 @@ import './DisplayForm.scss';
 
 Formio.use(gds);
 
-const DisplayForm = ({
-  form,
-  handleOnCancel,
-  handleOnSubmit,
-  existingSubmission,
-  interpolateContext,
-  submitting,
-}) => {
+const DisplayForm = ({ form, handleOnCancel, handleOnSubmit, interpolateContext, submitting }) => {
   const [errorAlert, setErrorAlert] = useState();
   const [hasFormChanged, setHasFormChanged] = useState(false);
   const formRef = useRef();
@@ -157,7 +150,7 @@ const DisplayForm = ({
    * augmentedSubmission must have context included or it cannot pre-populate fields that rely on context.
    * We have kept interpolate() context to prevent any unwanted side effects of removing it from the parent form.
    */
-  const [augmentedSubmission] = useState(_.merge(existingSubmission, contexts));
+  const [augmentedSubmission] = useState(contexts);
   interpolate(form, { ...reformattedContexts });
 
   /*
@@ -336,7 +329,6 @@ const DisplayForm = ({
 };
 
 DisplayForm.defaultProps = {
-  existingSubmission: {},
   interpolateContext: null,
   submitting: false,
 };
@@ -351,7 +343,6 @@ DisplayForm.propTypes = {
   }).isRequired,
   handleOnCancel: PropTypes.func.isRequired,
   handleOnSubmit: PropTypes.func.isRequired,
-  existingSubmission: PropTypes.shape({ root: PropTypes.shape() }),
   interpolateContext: PropTypes.shape({ root: PropTypes.shape() }),
   submitting: PropTypes.bool,
 };

--- a/client/src/pages/forms/FormPage.jsx
+++ b/client/src/pages/forms/FormPage.jsx
@@ -118,7 +118,6 @@ const FormPage = ({ formId }) => {
         interpolateContext={{
           businessKey: businessKeyComponent ? businessKeyComponent.defaultValue : null,
         }}
-        existingSubmission={{}}
         handleOnSubmit={(data) => {
           setSubmitting(true);
           submitForm({

--- a/client/src/pages/tasks/TaskPage.jsx
+++ b/client/src/pages/tasks/TaskPage.jsx
@@ -56,7 +56,6 @@ const TaskPage = ({ taskId }) => {
             processDefinition,
             task: taskInfo,
           } = taskData.data;
-          let formSubmission = {};
           const formVariableSubmissionName = form ? `${form.name}::submissionData` : null;
 
           if (taskInfo.variables) {
@@ -77,10 +76,6 @@ const TaskPage = ({ taskId }) => {
                 variables[key] = variables[key].value;
               }
             });
-
-            formSubmission = variables[formVariableSubmissionName]
-              ? variables[formVariableSubmissionName]
-              : variables.submissionData;
           }
 
           const updatedVariables = _.omit(variables || {}, [
@@ -95,7 +90,6 @@ const TaskPage = ({ taskId }) => {
               data: {
                 variables: updatedVariables,
                 form,
-                formSubmission,
                 processInstance,
                 processDefinition,
                 task: taskInfo,
@@ -108,7 +102,6 @@ const TaskPage = ({ taskId }) => {
               data: {
                 variables: updatedVariables,
                 form: '', // force form to null as user should not be able to access it
-                formSubmission,
                 processInstance,
                 processDefinition,
                 task: taskInfo,
@@ -139,14 +132,7 @@ const TaskPage = ({ taskId }) => {
     return null;
   }
 
-  const {
-    form,
-    processInstance,
-    task: taskInfo,
-    processDefinition,
-    formSubmission,
-    variables,
-  } = task.data;
+  const { form, processInstance, task: taskInfo, processDefinition, variables } = task.data;
 
   const handleOnFailure = () => {
     setSubmitting(false);
@@ -176,7 +162,6 @@ const TaskPage = ({ taskId }) => {
               handleOnCancel={async () => {
                 await navigation.navigate('/tasks');
               }}
-              existingSubmission={formSubmission}
               interpolateContext={{
                 processContext: {
                   /*


### PR DESCRIPTION
## AC

While investigating how to stop form fields pre-populating unexpectedly (no localStorage for that form, but form is populated with data), tracked down that it was coming from existingSubmission being set.

However, digging into that showed that existingSubmission had become redundant. We believed it was passing data to prepopulate a task, but looking at the way we now add context to tasks based on businessKey/processInstance/taskContext we no longer need a variable to pass this data down, we form it on the task as the form creates.

So, remove existingSubmission and it's associated formSubmission.

## To test

- submit a collect-event-at-border form
- > you should see the follow on form as normal
- submit the follow on form
- > you should be able to complete the event at border in a single form session

- submit a covid-compliance-check form with submit again ticked
- > you should be able to submit the form 
- > you should see a new instance of the form without saved data

- open your tasks
- select a journeyEaB task
- select a mode of transport
- close that task
- open a different journeyEaB task
- > the mode of transport SHOULD NOT be prefilled
- submit this task
- > you should be able to complete the submission