### PR TITLE
COP-3973 Persist partially filled forms

### DIFF
--- a/client/src/components/form/DisplayForm.jsx
+++ b/client/src/components/form/DisplayForm.jsx
@@ -171,12 +171,12 @@ const DisplayForm = ({
    */
   useEffect(() => {
     // Create a reference based on whether this is a task or a new form instance
-    if (interpolateContext.taskContext) {
+    if (!interpolateContext || !interpolateContext.taskContext) {
+      setLocalStorageReference(`form-${form.name}`);
+    } else {
       setLocalStorageReference(
         `form-${interpolateContext.taskContext.formKey}-${interpolateContext.taskContext.processInstanceId}`
       );
-    } else {
-      setLocalStorageReference(`form-${form.name}`);
     }
   }, []);
 

--- a/client/src/components/form/DisplayForm.jsx
+++ b/client/src/components/form/DisplayForm.jsx
@@ -305,7 +305,7 @@ const DisplayForm = ({
             end: new Date(),
             submitted: true,
           });
-          handleOnSubmit(submissionData);
+          handleOnSubmit(submissionData, localStorageReference);
         }}
         onChange={(data) => {
           // If we remove this set state the context does not load correctly

--- a/client/src/components/form/DisplayForm.jsx
+++ b/client/src/components/form/DisplayForm.jsx
@@ -14,6 +14,7 @@ import Logger from '../../utils/logger';
 import ApplicationSpinner from '../ApplicationSpinner';
 import FileService from '../../utils/FileService';
 import FormErrorsAlert from '../alert/FormErrorsAlert';
+import SecureLocalStorageManager from '../../utils/SecureLocalStorageManager';
 import './DisplayForm.scss';
 
 Formio.use(gds);
@@ -27,7 +28,9 @@ const DisplayForm = ({
   submitting,
 }) => {
   const [errorAlert, setErrorAlert] = useState();
+  const [augmentedSubmission, setAugmentedSubmission] = useState();
   const [hasFormChanged, setHasFormChanged] = useState(false);
+  const [localStorageReference, setLocalStorageReference] = useState();
   const formRef = useRef();
   const host = `${window.location.protocol}//${window.location.hostname}${
     window.location.port ? `:${window.location.port}` : ''
@@ -157,8 +160,35 @@ const DisplayForm = ({
    * augmentedSubmission must have context included or it cannot pre-populate fields that rely on context.
    * We have kept interpolate() context to prevent any unwanted side effects of removing it from the parent form.
    */
-  const [augmentedSubmission] = useState(_.merge(existingSubmission, contexts));
   interpolate(form, { ...reformattedContexts });
+
+  /* Storing users answers to retain them on page refresh:
+   * Answers will persist on return to this page except
+   * - when user has submitted the form
+   * - or when user has gone to the Dashboard (answers are cleared there)
+   * On pageload, once we have obtained the formName, we check if there is data for this form in localStorage
+   * - if there is localStorage data, we use it to create the data for the submission prop for the <Form> component
+   */
+  useEffect(() => {
+    // Create a reference based on whether this is a task or a new form instance
+    if (interpolateContext.taskContext) {
+      setLocalStorageReference(
+        `form-${interpolateContext.taskContext.formKey}-${interpolateContext.taskContext.processInstanceId}`
+      );
+    } else {
+      setLocalStorageReference(`form-${form.name}`);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (localStorageReference && !SecureLocalStorageManager.get(localStorageReference)) {
+      setAugmentedSubmission(_.merge(existingSubmission, contexts));
+    } else {
+      setAugmentedSubmission(
+        _.merge(SecureLocalStorageManager.get(localStorageReference), contexts)
+      );
+    }
+  }, [localStorageReference]);
 
   /*
    * The plugin below is required for when nested forms are present. These nested forms
@@ -283,6 +313,10 @@ const DisplayForm = ({
           if (formRef.current) {
             validate(formRef.current.formio, data);
           }
+          SecureLocalStorageManager.set(localStorageReference, {
+            data: data.data,
+            metadata: data.metadata,
+          });
         }}
         onError={(errors) => {
           setErrorAlert({
@@ -352,7 +386,7 @@ DisplayForm.propTypes = {
   handleOnCancel: PropTypes.func.isRequired,
   handleOnSubmit: PropTypes.func.isRequired,
   existingSubmission: PropTypes.shape({ root: PropTypes.shape() }),
-  interpolateContext: PropTypes.shape({ root: PropTypes.shape() }),
+  interpolateContext: PropTypes.shape({ taskContext: PropTypes.shape() }),
   submitting: PropTypes.bool,
 };
 

--- a/client/src/components/form/hooks.js
+++ b/client/src/components/form/hooks.js
@@ -14,7 +14,16 @@ export default () => {
   const currentUser = keycloak.tokenParsed.email;
 
   const submitForm = useCallback(
-    ({ submission, form, id, businessKey, handleOnFailure, handleOnRepeat, submitPath }) => {
+    ({
+      submission,
+      form,
+      id,
+      businessKey,
+      handleOnFailure,
+      handleOnRepeat,
+      submitPath,
+      reference,
+    }) => {
       if (form) {
         const variables = {
           [form.name]: {
@@ -41,7 +50,7 @@ export default () => {
                 if (response.data.length > 0 && response.data[0].assignee === currentUser) {
                   navigation.navigate(`/tasks/${response.data[0].id}`);
                 } else if (submission.data.submitAgain === true) {
-                  handleOnRepeat();
+                  handleOnRepeat(reference);
                 } else {
                   setAlertContext({
                     type: 'form-submission',

--- a/client/src/pages/forms/FormPage.jsx
+++ b/client/src/pages/forms/FormPage.jsx
@@ -10,6 +10,7 @@ import { useAxios, useIsMounted } from '../../utils/hooks';
 import ApplicationSpinner from '../../components/ApplicationSpinner';
 import apiHooks from '../../components/form/hooks';
 import DisplayForm from '../../components/form/DisplayForm';
+import SecureLocalStorageManager from '../../utils/SecureLocalStorageManager';
 import './Forms.scss';
 
 const FormPage = ({ formId }) => {
@@ -100,9 +101,10 @@ const FormPage = ({ formId }) => {
   const handleOnFailure = () => {
     setSubmitting(false);
   };
-  const handleOnRepeat = () => {
+  const handleOnRepeat = (reference) => {
     setSubmitting(false);
     setRepeat(true);
+    SecureLocalStorageManager.remove(reference);
     window.scrollTo(0, 0);
   };
 
@@ -119,7 +121,7 @@ const FormPage = ({ formId }) => {
           businessKey: businessKeyComponent ? businessKeyComponent.defaultValue : null,
         }}
         existingSubmission={{}}
-        handleOnSubmit={(data) => {
+        handleOnSubmit={(data, reference) => {
           setSubmitting(true);
           submitForm({
             submission: data,
@@ -129,6 +131,7 @@ const FormPage = ({ formId }) => {
             handleOnFailure,
             handleOnRepeat,
             submitPath: 'process-definition/key',
+            reference,
           });
         }}
       />

--- a/client/src/pages/home/index.jsx
+++ b/client/src/pages/home/index.jsx
@@ -6,6 +6,7 @@ import axios from 'axios';
 import { useMatomo } from '@datapunt/matomo-tracker-react';
 import Card from './components/Card';
 import { useIsMounted, useAxios } from '../../utils/hooks';
+import SecureLocalStorageManager from '../../utils/SecureLocalStorageManager';
 
 const Home = () => {
   const { t } = useTranslation();
@@ -27,6 +28,24 @@ const Home = () => {
 
   useEffect(() => {
     trackPageView();
+  }, []);
+
+  /*
+   * Whenever a user returns to the dashboard we want to clear any form data from localStorage
+   * This currently also clears form data from a successfully submitted form as they return a user to the Dashboard
+   */
+  useEffect(() => {
+    const removeArray = [];
+    // eslint-disable-next-line no-plusplus
+    for (let i = 0; i < localStorage.length; i++) {
+      if (localStorage.key(i).indexOf('form') !== -1) {
+        removeArray.push(localStorage.key(i));
+      }
+    }
+    // eslint-disable-next-line no-plusplus
+    for (let i = 0; i < removeArray.length; i++) {
+      SecureLocalStorageManager.remove(removeArray[i]);
+    }
   }, []);
 
   useEffect(() => {

--- a/client/src/pages/home/index.jsx
+++ b/client/src/pages/home/index.jsx
@@ -42,10 +42,7 @@ const Home = () => {
         removeArray.push(localStorage.key(i));
       }
     }
-    // eslint-disable-next-line no-plusplus
-    for (let i = 0; i < removeArray.length; i++) {
-      SecureLocalStorageManager.remove(removeArray[i]);
-    }
+    removeArray.forEach((item) => SecureLocalStorageManager.remove(item));
   }, []);
 
   useEffect(() => {


### PR DESCRIPTION
## AC

On forms, if you refresh, any fields you've already filled in will persist so you don't need to start again.

## Updated

- index.js to clear all form related storage when you return home (to Dashboard)
- displayForm to store form details on Change
- displayForm to retrieve details if they exist on pageLoad
- hooks.js, FormPage, and displayForm to handle repeatForms where we do not want fields to persist on submit, but where user will not have returned home between form loads

## Notes
There is a bug in Scenario 6 below that exists on v1, and v2dev. It is not related to localStorage so will be investigated in another ticket.

## Test Scenarios

#### Scenario 1

- start new form fresh
- enter some fields
- refresh page

> answers should persist

#### Scenario 2

- start new form fresh
- enter some fields
- go to edit my profile
- return to form via back button

> answers should persist

#### Scenario 3

- start new form fresh
- enter some fields
- go to dashboard

> answers should NOT persist

#### Scenario 4

- start new form fresh
- enter some fields
- complete the form
- submit the form
- return to form

> answers should not persist

#### Scenario 5

- open a task
- enter some fields
- refresh page

> answers should persist

#### ~~Scenario 6~~

- ~~open a task of the same type as in scenario 5~~

> ~~answers should NOT persist~~
See notes, this scenario fails due to an unrelated bug.

#### Scenario 7

- open covid-compliance-form
- complete the form including selecting submit another

> answers should NOT persist