### PR TITLE
Add user email to localStorageReference

### DIFF
--- a/client/src/components/form/DisplayForm.jsx
+++ b/client/src/components/form/DisplayForm.jsx
@@ -172,10 +172,10 @@ const DisplayForm = ({
   useEffect(() => {
     // Create a reference based on whether this is a task or a new form instance
     if (!interpolateContext || !interpolateContext.taskContext) {
-      setLocalStorageReference(`form-${form.name}`);
+      setLocalStorageReference(`form-${form.name}-${keycloak.tokenParsed.email}`);
     } else {
       setLocalStorageReference(
-        `form-${interpolateContext.taskContext.formKey}-${interpolateContext.taskContext.processInstanceId}`
+        `form-${interpolateContext.taskContext.formKey}-${interpolateContext.taskContext.processInstanceId}-${keycloak.tokenParsed.email}`
       );
     }
   }, []);


### PR DESCRIPTION
## AC

In UI1 this data is stored and retrieved per user, because otherwise there’s the possibility that BF users on a shared machine may get fields populated with each other’s data

## Updated

- added user email to localStorageReference (as is done in v1)

## Notes
There is a bug in Scenario 6 below that exists on v1, and v2dev. It is not related to localStorage so will be investigated in another ticket.

## Test Scenarios

#### Scenario 1

- start new form fresh
- enter some fields
- refresh page

> answers should persist

#### Scenario 2

- start new form fresh
- enter some fields
- go to edit my profile
- return to form via back button

> answers should persist

#### Scenario 3

- start new form fresh
- enter some fields
- go to dashboard

> answers should NOT persist

#### Scenario 4

- start new form fresh
- enter some fields
- complete the form
- submit the form
- return to form

> answers should not persist

#### Scenario 5

- open a task
- enter some fields
- refresh page

> answers should persist

#### ~~Scenario 6~~

- ~~open a task of the same type as in scenario 5~~

> ~~answers should NOT persist~~
See notes, this scenario fails due to an unrelated bug.

#### Scenario 7

- open covid-compliance-form
- complete the form including selecting submit another

> answers should NOT persist