### PR TITLE
Revert augmentedSubmission

### DIFF
--- a/client/src/components/form/DisplayForm.jsx
+++ b/client/src/components/form/DisplayForm.jsx
@@ -28,7 +28,6 @@ const DisplayForm = ({
   submitting,
 }) => {
   const [errorAlert, setErrorAlert] = useState();
-  const [augmentedSubmission, setAugmentedSubmission] = useState();
   const [hasFormChanged, setHasFormChanged] = useState(false);
   const [localStorageReference, setLocalStorageReference] = useState();
   const formRef = useRef();
@@ -180,15 +179,8 @@ const DisplayForm = ({
     }
   }, []);
 
-  useEffect(() => {
-    if (localStorageReference && !SecureLocalStorageManager.get(localStorageReference)) {
-      setAugmentedSubmission(_.merge(existingSubmission, contexts));
-    } else {
-      setAugmentedSubmission(
-        _.merge(SecureLocalStorageManager.get(localStorageReference), contexts)
-      );
-    }
-  }, [localStorageReference]);
+  // Temporarily removed the retrieving from local storage while investigate a bug with existing submission data and contexts
+  const [augmentedSubmission] = useState(_.merge(existingSubmission, contexts));
 
   /*
    * The plugin below is required for when nested forms are present. These nested forms


### PR DESCRIPTION
Temporary fix as discovered contexts is being lost at form creation. This fix breaks localStorage but we will continue working on that

This reverts the augmentedSubmission object to being created as it was originally, and removes the useEffect that was retrieving from localStorage when available