### PR TITLE
COP-5519: Differing data types in the shiftDetailsContext object across v1 and v2

### DIFF
--- a/client/src/components/form/DisplayForm.jsx
+++ b/client/src/components/form/DisplayForm.jsx
@@ -111,7 +111,7 @@ const DisplayForm = ({
       },
       shiftDetailsContext: {
         email,
-        locationid: defaultlocationid,
+        locationid: String(defaultlocationid),
         phone,
         roles,
         team,

--- a/client/src/pages/cases/components/CaseAction.jsx
+++ b/client/src/pages/cases/components/CaseAction.jsx
@@ -104,7 +104,8 @@ const CaseAction = ({
       },
       shiftDetailsContext: {
         email,
-        locationid: defaultlocationid,
+        // Coorce location id to a string in line with v1
+        locationid: String(defaultlocationid),
         phone,
         roles,
         team,

--- a/client/src/utils/hooks.js
+++ b/client/src/utils/hooks.js
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef, useContext } from 'react';
 import axios from 'axios';
+import _ from 'lodash';
 
 import { useKeycloak } from '@react-keycloak/web';
 import { useCurrentRoute } from 'react-navi';
@@ -90,7 +91,11 @@ export const useFetchTeam = () => {
             );
             if (isMounted.current) {
               const team = response.data.data[0];
-              setTeam(team);
+              // Coerces values of team object from numbers to strings to use in shift
+              const reformattedTeam = _.mapValues(team, (elem) => {
+                return typeof elem === 'number' ? String(elem) : elem;
+              });
+              setTeam(reformattedTeam);
             }
           } else {
             // TODO: Redirect the user here because they have no teamid in KC...


### PR DESCRIPTION
# Description
This branch changes the number values in the shiftDetailsContext to strings, to be in line with the data types in v1. See ticket for further details and comparison with v1: https://support.cop.homeoffice.gov.uk/browse/COP-5519. 

In v1, the shiftDetailsContext is defined through the submission of a shift form, which is why the data is in string format. In v2, we are building the context through a call to ref data and using keycloak, so the numbers are type number. To avoid any issues with potential type errors, the hook setting team context has been updated along with the location ID in DisplayForm and CaseActions. 

To test: 
- submit a form either on the forms page or in case actions. 
- check the payload or look in cockpit at the submission data. Find the shiftDetailsContext. You will see that the values which are numerical are string type e.g.
```
      "ministryid": "1",
      "departmentid": "1",
      "directorateid": "2",
```
- submit a form on v1 and check the submission data in cockpit. The shiftDetailsContext will be of the same type as on v2. 
