### PR TITLE
COP-5665 Remove async from beforeCancel hook

### DIFF
--- a/client/src/components/form/DisplayForm.jsx
+++ b/client/src/components/form/DisplayForm.jsx
@@ -324,7 +324,7 @@ const DisplayForm = ({
           noAlerts: true,
           fileService,
           hooks: {
-            beforeCancel: async () => {
+            beforeCancel: () => {
               setTime({
                 ...time,
                 end: new Date(),


### PR DESCRIPTION
### AC
The user should be able to cancel from form view and NOT have a confirm box appear

### Updated
- Removed `async` from `beforeCancel` hook, this hook should not be asynchronous for the purpose of which we are using it

### To test
- Pull and run cop locally pointing proxy to dev
- Login
- Navigate to `/forms`
- Select a form
- When the form loads, click the `Cancel` button at the bottom right hand side of the form
- *You should NOT have a confirm box appear*
- *You should be taken to the `/forms` page successfully*
- Repeat this process for several forms