### PR TITLE
Add zuul host timeout to test if timeouts are causing 500 errors

### DIFF
--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -32,6 +32,9 @@ server:
 
 
 zuul:
+  host:
+    connect-timeout-millis: 120000
+    socket-timeout-millis: 120000
   routes:
     fileupload-service:
       path: /files/**


### PR DESCRIPTION
Testing while after a file upload we receive a 500 error - cannot test file uploading locally 

This is setting timeouts on the zuul proxying to test if that is the problem, set to 2min for test