### PR TITLE
COP-5666: Add copy case link button functionality

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -101,7 +101,7 @@
       "npm run lint"
     ]
   },
-  "proxy": "https://cop-ui.dev.cop.homeoffice.gov.uk/",
+  "proxy": "http://localhost:8004",
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",

--- a/client/package.json
+++ b/client/package.json
@@ -27,6 +27,7 @@
     "prop-types": "^15.7.2",
     "query-string": "^5.1.1",
     "react": "^16.13.1",
+    "react-copy-to-clipboard": "^5.0.3",
     "react-dom": "^16.13.1",
     "react-error-boundary": "^2.2.1",
     "react-formio": "^4.3.0",
@@ -100,7 +101,7 @@
       "npm run lint"
     ]
   },
-  "proxy": "http://localhost:8004",
+  "proxy": "https://cop-ui.dev.cop.homeoffice.gov.uk/",
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",

--- a/client/public/locales/en-GB/translation.json
+++ b/client/public/locales/en-GB/translation.json
@@ -86,7 +86,8 @@
           "form-loading": "Loading form..."
         },
         "case-intro": {
-          "copy-button": "Copy case link"
+          "copy-button-uncopied": "Copy case link",
+          "copy-button-copied": "Case link copied"
         },
         "case-metrics": {
           "heading": "Case metrics",

--- a/client/src/pages/cases/components/CaseIntro.jsx
+++ b/client/src/pages/cases/components/CaseIntro.jsx
@@ -1,9 +1,11 @@
-import React from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { useTranslation } from 'react-i18next';
+import { CopyToClipboard } from 'react-copy-to-clipboard';
 
 const CaseIntro = ({ businessKey }) => {
   const { t } = useTranslation();
+  const [caseUrlCopied, setCaseUrlCopied] = useState(false);
 
   return (
     <>
@@ -11,13 +13,20 @@ const CaseIntro = ({ businessKey }) => {
         <h2 className="govuk-heading-m">{businessKey}</h2>
       </div>
       <div className="govuk-grid-column-one-half">
-        <button
-          type="button"
-          style={{ float: 'right' }}
-          className="govuk-button govuk-button--secondary"
+        <CopyToClipboard
+          text={`${window.location.origin}/cases/${businessKey}`}
+          onCopy={() => setCaseUrlCopied(true)}
         >
-          {t('pages.cases.details-panel.case-intro.copy-button')}
-        </button>
+          <button
+            type="button"
+            style={{ float: 'right' }}
+            className="govuk-button govuk-button--secondary"
+          >
+            {caseUrlCopied
+              ? t('pages.cases.details-panel.case-intro.copy-button-copied')
+              : t('pages.cases.details-panel.case-intro.copy-button-uncopied')}
+          </button>
+        </CopyToClipboard>
       </div>
     </>
   );


### PR DESCRIPTION
Description
- Adds functionality to the "Copy case link" button on Cases details panel. 

To test: 
- run locally and go to the Cases page. 
- search for any case and click on one. 
- In the top panel of the Case details panel is the copy button. Click this and then test it has copied to your clipboard. 
