### PR TITLE
COP-5475 Add context to hidden component for case actions

### DIFF
--- a/client/src/pages/cases/components/CaseAction.jsx
+++ b/client/src/pages/cases/components/CaseAction.jsx
@@ -23,17 +23,14 @@ const CaseAction = ({
   const isMounted = useIsMounted();
   const [submitting, setSubmitting] = useState(false);
   const [submissionConfirmation, showSubmissionConfirmation] = useState(false);
-  const [hasFormChanged, setHasFormChanged] = useState(false);
-  const host = `${window.location.protocol}//${window.location.hostname}${
-    window.location.port ? `:${window.location.port}` : ''
-  }`;
-
   const [form, setForm] = useState({
     isLoading: false,
     data: null,
   });
-
   const [keycloak] = useKeycloak();
+  const host = `${window.location.protocol}//${window.location.hostname}${
+    window.location.port ? `:${window.location.port}` : ''
+  }`;
 
   const {
     authServerUrl: url,
@@ -160,7 +157,6 @@ const CaseAction = ({
       showSubmissionConfirmation(true);
       setTimeout(() => {
         getCaseDetails(businessKey);
-        showSubmissionConfirmation(false);
       }, 5000);
     } catch (e) {
       setSubmitting(false);
@@ -236,10 +232,7 @@ const CaseAction = ({
             setSubmitting(true);
             handleOnSubmit(submissionData, form.data);
           }}
-          onChange={() => {
-            // If we remove this set state the context does not load correctly
-            setHasFormChanged(!hasFormChanged);
-          }}
+          submission={{ ...contexts }}
           options={{
             noAlerts: true,
             breadcrumbSettings: {
@@ -261,12 +254,12 @@ const CaseAction = ({
                     definitionId: selectedActionProcessId,
                   },
                 };
-                submissionData.data.shiftDetailsContext = contexts.data.shiftDetailsContext;
-                submissionData.data.extendedStaffDetailsContext =
-                  contexts.data.extendedStaffDetailsContext;
-                submissionData.data.environmentContext = contexts.data.environmentContext;
+                delete submissionData.data.processContext;
+                delete submissionData.data.taskContext;
+                delete submissionData.data.keycloakContext;
+                delete submissionData.data.staffDetailsDataContext;
+                delete submissionData.data.caseDetails;
                 submissionData.data.caseBusinessKey = contexts.data.businessKey;
-                submissionData.data.businessKey = contexts.data.businessKey;
                 submissionData.data.processKey = selectedActionId;
                 submissionData.data.variableName = form.data.name;
                 /* eslint-enable no-param-reassign, no-shadow */


### PR DESCRIPTION
### AC
When a user submits a case action, all context related properties should be resolved correctly.

### Updates
- Passed `submission` prop with the `contexts` object down to the `Form` component
- As a result of passing `submission`, context now needs to be removed in the `beforeSubmit`
- Removed `showSubmissionConfirmation` in `setTimeout` to avoid state updates after unmounting

### Notes
- With the downgrade of `formiojs`, bugs in the `Form` component are not present i.e. allowing us to pass a `submission` prop down without the object being passed down overwriting key values unexpectedly.

### To test
- Pull and run cop locally pointing proxy to dev environment
- Login
- Submit form that generates multiple case actions
- Go to case that has been created
- Open the network tab in dev tools
- Submit a `Record action` form
- Assess the payload, make sure to check there are no templates (`{{ VALUE IN HERE }}`) in the payload and that they have all been resolved correctly
- Check the payload in cockpit to ensure the payload is still as expected