### PR TITLE
COP-5732 Inspect request payload for task form submission

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -5579,6 +5579,14 @@
       "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
     },
+    "copy-to-clipboard": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/copy-to-clipboard/-/copy-to-clipboard-3.3.1.tgz",
+      "integrity": "sha512-i13qo6kIHTTpCm8/Wup+0b1mVWETvu2kIMzKoK8FpkLkFxlt0znUAHcMzox+T8sPlqtZXq3CulEjQHsYiGFJUw==",
+      "requires": {
+        "toggle-selection": "^1.0.6"
+      }
+    },
     "core-js": {
       "version": "2.6.12",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
@@ -16938,6 +16946,15 @@
         }
       }
     },
+    "react-copy-to-clipboard": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/react-copy-to-clipboard/-/react-copy-to-clipboard-5.0.3.tgz",
+      "integrity": "sha512-9S3j+m+UxDZOM0Qb8mhnT/rMR0NGSrj9A/073yz2DSxPMYhmYFBMYIdI2X4o8AjOjyFsSNxDRnCX6s/gRxpriw==",
+      "requires": {
+        "copy-to-clipboard": "^3",
+        "prop-types": "^15.5.8"
+      }
+    },
     "react-dev-utils": {
       "version": "11.0.1",
       "resolved": "https://registry.npmjs.org/react-dev-utils/-/react-dev-utils-11.0.1.tgz",
@@ -19737,6 +19754,11 @@
       "requires": {
         "is-number": "^7.0.0"
       }
+    },
+    "toggle-selection": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/toggle-selection/-/toggle-selection-1.0.6.tgz",
+      "integrity": "sha1-bkWxJj8gF/oKzH2J14sVuL932jI="
     },
     "toidentifier": {
       "version": "1.0.0",

--- a/client/src/components/form/DisplayForm.jsx
+++ b/client/src/components/form/DisplayForm.jsx
@@ -19,14 +19,7 @@ import './DisplayForm.scss';
 
 Formio.use(gds);
 
-const DisplayForm = ({
-  form,
-  handleOnCancel,
-  handleOnSubmit,
-  existingSubmission,
-  interpolateContext,
-  submitting,
-}) => {
+const DisplayForm = ({ form, handleOnCancel, handleOnSubmit, interpolateContext, submitting }) => {
   const [errorAlert, setErrorAlert] = useState();
   const [hasFormChanged, setHasFormChanged] = useState(false);
   const [localStorageReference, setLocalStorageReference] = useState();
@@ -179,8 +172,8 @@ const DisplayForm = ({
     }
   }, []);
 
-  // Temporarily removed the retrieving from local storage while investigate a bug with existing submission data and contexts
-  const [augmentedSubmission] = useState(_.merge(existingSubmission, contexts));
+  // Need to revisit to merge existing form answers to prefill corretly
+  const [augmentedSubmission] = useState(contexts);
 
   /*
    * The plugin below is required for when nested forms are present. These nested forms
@@ -362,7 +355,6 @@ const DisplayForm = ({
 };
 
 DisplayForm.defaultProps = {
-  existingSubmission: {},
   interpolateContext: null,
   submitting: false,
 };
@@ -377,7 +369,6 @@ DisplayForm.propTypes = {
   }).isRequired,
   handleOnCancel: PropTypes.func.isRequired,
   handleOnSubmit: PropTypes.func.isRequired,
-  existingSubmission: PropTypes.shape({ root: PropTypes.shape() }),
   interpolateContext: PropTypes.shape({ taskContext: PropTypes.shape() }),
   submitting: PropTypes.bool,
 };

--- a/client/src/pages/forms/FormPage.jsx
+++ b/client/src/pages/forms/FormPage.jsx
@@ -120,7 +120,6 @@ const FormPage = ({ formId }) => {
         interpolateContext={{
           businessKey: businessKeyComponent ? businessKeyComponent.defaultValue : null,
         }}
-        existingSubmission={{}}
         handleOnSubmit={(data, reference) => {
           setSubmitting(true);
           submitForm({

--- a/client/src/pages/tasks/TaskPage.jsx
+++ b/client/src/pages/tasks/TaskPage.jsx
@@ -53,7 +53,6 @@ const TaskPage = ({ taskId }) => {
             processDefinition,
             task: taskInfo,
           } = taskData.data;
-          let formSubmission = {};
           const formVariableSubmissionName = form ? `${form.name}::submissionData` : null;
 
           if (taskInfo.variables) {
@@ -74,10 +73,6 @@ const TaskPage = ({ taskId }) => {
                 variables[key] = variables[key].value;
               }
             });
-
-            formSubmission = variables[formVariableSubmissionName]
-              ? variables[formVariableSubmissionName]
-              : variables.submissionData;
           }
 
           const updatedVariables = _.omit(variables || {}, [
@@ -92,7 +87,6 @@ const TaskPage = ({ taskId }) => {
               data: {
                 variables: updatedVariables,
                 form,
-                formSubmission,
                 processInstance,
                 processDefinition,
                 task: taskInfo,
@@ -104,7 +98,6 @@ const TaskPage = ({ taskId }) => {
               data: {
                 variables: updatedVariables,
                 form: '', // force form to null as user should not be able to access it
-                formSubmission,
                 processInstance,
                 processDefinition,
                 task: taskInfo,
@@ -130,14 +123,7 @@ const TaskPage = ({ taskId }) => {
     return null;
   }
 
-  const {
-    form,
-    processInstance,
-    task: taskInfo,
-    processDefinition,
-    formSubmission,
-    variables,
-  } = task.data;
+  const { form, processInstance, task: taskInfo, processDefinition, variables } = task.data;
 
   const handleOnFailure = () => {
     setSubmitting(false);
@@ -166,7 +152,6 @@ const TaskPage = ({ taskId }) => {
               handleOnCancel={async () => {
                 await navigation.navigate('/tasks');
               }}
-              existingSubmission={formSubmission}
               interpolateContext={{
                 processContext: {
                   /*


### PR DESCRIPTION
The `existingSubmission` prop passed down to the `DisplayForm` component has caused unexpected behaviour in relation for form pre-population. As local storage will be responsible for the form response persistence feature, existingSubmission has been removed to avoid confusion and prepare the code for local storage implementation.