### PR TITLE
COP-5730 Update localStorage storing/deleting for persisting form data

### DIFF
--- a/client/src/components/form/DisplayForm.jsx
+++ b/client/src/components/form/DisplayForm.jsx
@@ -173,7 +173,7 @@ const DisplayForm = ({
       setAugmentedSubmission(contexts);
     } else {
       const localData = SecureLocalStorageManager.get(localStorageReference);
-      setAugmentedSubmission(_.merge(localData, contexts));
+      setAugmentedSubmission(_.merge({ ...localData }, contexts));
     }
   }, []);
 

--- a/client/src/components/form/DisplayForm.jsx
+++ b/client/src/components/form/DisplayForm.jsx
@@ -172,9 +172,8 @@ const DisplayForm = ({
     if (!SecureLocalStorageManager.get(localStorageReference)) {
       setAugmentedSubmission(contexts);
     } else {
-      setAugmentedSubmission(
-        _.merge(SecureLocalStorageManager.get(localStorageReference), contexts)
-      );
+      const localData = SecureLocalStorageManager.get(localStorageReference);
+      setAugmentedSubmission(_.merge(localData, contexts));
     }
   }, []);
 

--- a/client/src/components/form/hooks.js
+++ b/client/src/components/form/hooks.js
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next';
 import { useNavigation } from 'react-navi';
 import { useAxios } from '../../utils/hooks';
 import { AlertContext } from '../../utils/AlertContext';
+import SecureLocalStorageManager from '../../utils/SecureLocalStorageManager';
 
 export default () => {
   const axiosInstance = useAxios();
@@ -22,7 +23,7 @@ export default () => {
       handleOnFailure,
       handleOnRepeat,
       submitPath,
-      reference,
+      localStorageReference,
     }) => {
       if (form) {
         const variables = {
@@ -45,12 +46,13 @@ export default () => {
             axiosInstance
               .get(`/camunda/engine-rest/task?processInstanceBusinessKey=${businessKey}`)
               .then((response) => {
+                SecureLocalStorageManager.remove(localStorageReference);
                 // This will automatically open the next form available (if one exists for this user)
                 // We can only ever open one task in this manner and so always take the first available
                 if (response.data.length > 0 && response.data[0].assignee === currentUser) {
                   navigation.navigate(`/tasks/${response.data[0].id}`);
                 } else if (submission.data.submitAgain === true) {
-                  handleOnRepeat(reference);
+                  handleOnRepeat();
                 } else {
                   setAlertContext({
                     type: 'form-submission',

--- a/client/src/pages/forms/FormPage.jsx
+++ b/client/src/pages/forms/FormPage.jsx
@@ -10,7 +10,6 @@ import { useAxios, useIsMounted } from '../../utils/hooks';
 import ApplicationSpinner from '../../components/ApplicationSpinner';
 import apiHooks from '../../components/form/hooks';
 import DisplayForm from '../../components/form/DisplayForm';
-import SecureLocalStorageManager from '../../utils/SecureLocalStorageManager';
 import './Forms.scss';
 
 const FormPage = ({ formId }) => {
@@ -101,10 +100,9 @@ const FormPage = ({ formId }) => {
   const handleOnFailure = () => {
     setSubmitting(false);
   };
-  const handleOnRepeat = (reference) => {
+  const handleOnRepeat = () => {
     setSubmitting(false);
     setRepeat(true);
-    SecureLocalStorageManager.remove(reference);
     window.scrollTo(0, 0);
   };
 
@@ -113,7 +111,7 @@ const FormPage = ({ formId }) => {
       <h1 className="govuk-heading-l">{pageHeading}</h1>
       <DisplayForm
         submitting={submitting}
-        localStorageReference={form.data.name}
+        localStorageReference={`form-${form.data.name}`}
         form={form.data}
         handleOnCancel={async () => {
           await navigation.navigate('/forms');
@@ -121,7 +119,7 @@ const FormPage = ({ formId }) => {
         interpolateContext={{
           businessKey: businessKeyComponent ? businessKeyComponent.defaultValue : null,
         }}
-        handleOnSubmit={(data, reference) => {
+        handleOnSubmit={(data, localStorageReference) => {
           setSubmitting(true);
           submitForm({
             submission: data,
@@ -131,7 +129,7 @@ const FormPage = ({ formId }) => {
             handleOnFailure,
             handleOnRepeat,
             submitPath: 'process-definition/key',
-            reference,
+            localStorageReference,
           });
         }}
       />

--- a/client/src/pages/forms/FormPage.jsx
+++ b/client/src/pages/forms/FormPage.jsx
@@ -113,6 +113,7 @@ const FormPage = ({ formId }) => {
       <h1 className="govuk-heading-l">{pageHeading}</h1>
       <DisplayForm
         submitting={submitting}
+        localStorageReference={form.data.name}
         form={form.data}
         handleOnCancel={async () => {
           await navigation.navigate('/forms');

--- a/client/src/pages/tasks/TaskPage.jsx
+++ b/client/src/pages/tasks/TaskPage.jsx
@@ -148,7 +148,7 @@ const TaskPage = ({ taskId }) => {
           <div className="govuk-grid-column-full" id="form">
             <DisplayForm
               submitting={submitting}
-              localStorageReference={`${task.data.form.name}-${taskId}`}
+              localStorageReference={`form-${task.data.form.name}-${taskId}`}
               form={form}
               handleOnCancel={async () => {
                 await navigation.navigate('/tasks');

--- a/client/src/pages/tasks/TaskPage.jsx
+++ b/client/src/pages/tasks/TaskPage.jsx
@@ -148,6 +148,7 @@ const TaskPage = ({ taskId }) => {
           <div className="govuk-grid-column-full" id="form">
             <DisplayForm
               submitting={submitting}
+              localStorageReference={`${task.data.form.name}-${taskId}`}
               form={form}
               handleOnCancel={async () => {
                 await navigation.navigate('/tasks');


### PR DESCRIPTION
## AC

On forms, if you refresh, any fields you've already filled in will persist so you don't need to start again.

## Updated

- FormPage & TaskPage now create their `localStorageReference` and pass that down to DisplayForm
- DisplayForm checks for localStorage and merges that with `context` to create `augmentedSubmission`
- Clear localStorage for the form submitted on submission

## Test Scenarios

#### Scenario 1

- start new form fresh
- enter some fields
- refresh page

> answers should persist

#### Scenario 2

- start new form fresh
- enter some fields
- go to edit my profile
- return to form via back button

> answers should persist

#### Scenario 3

- start new form fresh
- enter some fields
- go to dashboard

> answers should NOT persist

#### Scenario 4

- start new form fresh
- enter some fields
- complete the form
- submit the form
- return to form

> answers should not persist

#### Scenario 5

- open a task
- enter some fields
- refresh page

> answers should persist

#### Scenario 6

- open a task of the same type as in scenario 5

> answers should NOT persist

#### Scenario 7

- open covid-compliance-form
- complete the form including selecting submit another

> answers should NOT persist