### PR TITLE
Add loading spinner for next page task

### DIFF
--- a/client/src/pages/tasks/TasksListPage.jsx
+++ b/client/src/pages/tasks/TasksListPage.jsx
@@ -54,6 +54,7 @@ const TasksListPage = ({ taskType }) => {
 
   useEffect(() => {
     const source = axios.CancelToken.source();
+    setData({ isLoading: true, tasks: [] });
     const loadTasks = async () => {
       if (axiosInstance) {
         try {


### PR DESCRIPTION
### AC
The task list page reflects the same behaviour as v1 when clicking on next page of tasks

### Updates
- Added `setData` at the beginning of the `useEffect` that fetches task data rendering the spinner for each task list query

### To test
- Pull and run cop locally pointing proxy to dev environment
- Login
- Go to group task list page
- Click on next pagination button at the bottom of task list
- *You should see an application spinner and then the new task list is rendered*
- Click on last pagination button at the bottom of the task list
- *You should see an application spinner and then the new task list is rendered*
