### PR TITLE
Fix application spinner rendering over whole task list page on state change

### DIFF
--- a/client/src/pages/tasks/TasksListPage.jsx
+++ b/client/src/pages/tasks/TasksListPage.jsx
@@ -30,6 +30,7 @@ const TasksListPage = ({ taskType }) => {
     tasks: [],
   });
   const [page, setPage] = useState(0);
+  const [areTasksLoading, setAreTasksLoading] = useState(true);
   const [taskCount, setTaskCount] = useState(0);
   const maxResults = 20;
   const isMounted = useIsMounted();
@@ -54,7 +55,7 @@ const TasksListPage = ({ taskType }) => {
 
   useEffect(() => {
     const source = axios.CancelToken.source();
-    setData({ isLoading: true, tasks: [] });
+    setAreTasksLoading(true);
     const loadTasks = async () => {
       if (axiosInstance) {
         try {
@@ -111,6 +112,7 @@ const TasksListPage = ({ taskType }) => {
               isLoading: false,
               tasks: [],
             });
+            setAreTasksLoading(false);
             setTaskCount(0);
           } else {
             // This generates a unique list of process definition ids to use for a call to camunda for task categories
@@ -162,6 +164,7 @@ const TasksListPage = ({ taskType }) => {
                 tasks: tasksResponse.data,
               });
               setTaskCount(taskCountResponse.data.count);
+              setAreTasksLoading(false);
             }
           }
         } catch (e) {
@@ -169,6 +172,7 @@ const TasksListPage = ({ taskType }) => {
             isLoading: false,
             tasks: [],
           });
+          setAreTasksLoading(false);
         }
       }
     };
@@ -211,19 +215,29 @@ const TasksListPage = ({ taskType }) => {
           handleFilters={handleFilters}
         />
       </div>
-      <div className="govuk-grid-row">
-        <div className="govuk-grid-column-full">
-          <TaskList tasks={data.tasks} groupBy={filters.groupBy} />
-          {data.tasks.length ? (
-            <TaskPagination
-              page={page}
-              setPage={setPage}
-              taskCount={taskCount}
-              maxResults={maxResults}
-            />
-          ) : null}
-        </div>
-      </div>
+      {areTasksLoading ? (
+        <ApplicationSpinner />
+      ) : (
+        <>
+          <div className="govuk-grid-row">
+            <div className="govuk-grid-column-full">
+              <TaskList
+                tasks={data.tasks}
+                groupBy={filters.groupBy}
+                areTasksLoading={areTasksLoading}
+              />
+              {data.tasks.length ? (
+                <TaskPagination
+                  page={page}
+                  setPage={setPage}
+                  taskCount={taskCount}
+                  maxResults={maxResults}
+                />
+              ) : null}
+            </div>
+          </div>
+        </>
+      )}
     </>
   );
 };


### PR DESCRIPTION
### AC
When a user searches for a task by name, the application spinner should only render in the TaskList and not remove the task filters and task count

### Updated
- Removed the initial `setData` from the `useEffect`.
- Added `areTasksLoading` state in order to conditionally render application spinner child components of `TaskListPage` (`TaskList` and `TaskPagination`)
- Added tests to `TaskListPage`

### Notes
As a result of the initial `TaskListPage` design, the application spinner was being rendered for every data change in replacement of the task filters and count. This meant when a user searched for a task, each change would result in the spinner rendering over the search bar until the new tasks were returned (essentially, type one letter and spinner appears with search bar being removed). In order to circumnavigate the issue, the `data.isLoading` is now only responsible for the initial call for tasks and a separate piece of state `areTasksLoading` is responsible for the conditional rendering of the `TaskList` and `TaskPagination` components. This means the task filters and count persist and are not removed when searching or filtering tasks. 

### To test
- Pull and run cop locally pointing the proxy to the dev env
- Login
- Navigate to `/tasks`
- *You should initially see an application spinner rendered before the first list of tasks is rendered*
- Search for a task by name (valid one)
- *You should see an application spinner render in the task list before the tasks are returned from the api*
- *The task filters and task count SHOULD persist when searching*
- Remove the search string
- Sort the tasks
- *You should see an application spinner render in the task list before the tasks are returned from the api*
- *The task filters and task count SHOULD persist when sorted tasks are queried*
- Group the tasks 
- *You should NOT see an application spinner render*
- *The task filters and task count SHOULD persist when tasks are grouped*
- Click the `Next` button at the bottom of the task list
- *You should see an application spinner render in the task list before the tasks are returned from the api*
- *The task filters and task count SHOULD persist when sorted tasks are queried*