### PR TITLE
COP-5799 Reset page number to 0 when task filtering has occurred

### DIFF
--- a/client/src/pages/tasks/TasksListPage.jsx
+++ b/client/src/pages/tasks/TasksListPage.jsx
@@ -24,7 +24,6 @@ const TasksListPage = ({ taskType }) => {
       : 'category',
     search: '',
   });
-
   const [data, setData] = useState({
     isLoading: true,
     tasks: [],
@@ -35,14 +34,7 @@ const TasksListPage = ({ taskType }) => {
   const maxResults = 20;
   const isMounted = useIsMounted();
   const axiosInstance = useAxios();
-  const handleFilters = (e) => {
-    const newFilterValues = { ...filters, [e.target.name]: e.target.value };
-    setFilters(newFilterValues);
-    if (e.target.name !== 'search') {
-      SecureLocalStorageManager.set(`${taskType}-tasksSortBy`, newFilterValues.sortBy);
-      SecureLocalStorageManager.set(`${taskType}-tasksGroupBy`, newFilterValues.groupBy);
-    }
-  };
+
   const formatSortByValue = (sortValue) => {
     const [sortOrder, sortVariable] = sortValue.split('-');
     return { sortOrder, sortVariable };
@@ -209,10 +201,10 @@ const TasksListPage = ({ taskType }) => {
       </div>
       <div>
         <TaskFilters
-          search={filters.search}
-          sortBy={filters.sortBy}
-          groupBy={filters.groupBy}
-          handleFilters={handleFilters}
+          filters={filters}
+          setFilters={setFilters}
+          setPage={setPage}
+          taskType={taskType}
         />
       </div>
       {areTasksLoading ? (

--- a/client/src/pages/tasks/components/TaskFilters.jsx
+++ b/client/src/pages/tasks/components/TaskFilters.jsx
@@ -1,7 +1,22 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import SecureLocalStorageManager from '../../../utils/SecureLocalStorageManager';
 
-const TaskFilters = ({ search, sortBy, groupBy, handleFilters }) => {
+const TaskFilters = ({ filters, setFilters, setPage, taskType }) => {
+  const handleSortBy = (e) => {
+    setFilters({ ...filters, sortBy: e.target.value });
+    setPage(0);
+    SecureLocalStorageManager.set(`${taskType}-tasksSortBy`, e.target.value);
+  };
+  const handleGroupBy = (e) => {
+    setFilters({ ...filters, groupBy: e.target.value });
+    SecureLocalStorageManager.set(`${taskType}-tasksGroupBy`, e.target.value);
+  };
+  const handleSearch = (e) => {
+    setFilters({ ...filters, search: e.target.value });
+    setPage(0);
+  };
+
   return (
     <div className="govuk-grid-row">
       <div className="govuk-grid-column-one-third">
@@ -13,8 +28,8 @@ const TaskFilters = ({ search, sortBy, groupBy, handleFilters }) => {
             className="govuk-select"
             id="sort"
             name="sortBy"
-            onChange={handleFilters}
-            value={sortBy}
+            onChange={handleSortBy}
+            value={filters.sortBy}
           >
             <option value="asc-dueDate">Oldest due date</option>
             <option value="desc-dueDate">Latest due date</option>
@@ -34,8 +49,8 @@ const TaskFilters = ({ search, sortBy, groupBy, handleFilters }) => {
             className="govuk-select"
             id="group"
             name="groupBy"
-            onChange={handleFilters}
-            value={groupBy}
+            onChange={handleGroupBy}
+            value={filters.groupBy}
           >
             <option value="category">Category</option>
             <option value="businessKey">BF Reference</option>
@@ -54,8 +69,8 @@ const TaskFilters = ({ search, sortBy, groupBy, handleFilters }) => {
             id="filterTaskName"
             type="text"
             name="search"
-            value={search}
-            onChange={handleFilters}
+            value={filters.search}
+            onChange={handleSearch}
           />
         </div>
       </div>
@@ -64,14 +79,20 @@ const TaskFilters = ({ search, sortBy, groupBy, handleFilters }) => {
 };
 
 TaskFilters.defaultProps = {
-  search: '',
+  filters: {
+    search: '',
+  },
 };
 
 TaskFilters.propTypes = {
-  handleFilters: PropTypes.func.isRequired,
-  search: PropTypes.string,
-  sortBy: PropTypes.string.isRequired,
-  groupBy: PropTypes.string.isRequired,
+  filters: PropTypes.shape({
+    sortBy: PropTypes.string.isRequired,
+    groupBy: PropTypes.string.isRequired,
+    search: PropTypes.string,
+  }),
+  setFilters: PropTypes.func.isRequired,
+  setPage: PropTypes.func.isRequired,
+  taskType: PropTypes.string.isRequired,
 };
 
 export default TaskFilters;

--- a/client/src/pages/tasks/components/TaskFilters.test.jsx
+++ b/client/src/pages/tasks/components/TaskFilters.test.jsx
@@ -1,50 +1,60 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { render, queryByAttribute, fireEvent } from '@testing-library/react';
 import TaskFilters from './TaskFilters';
 
 describe('TaskFilters', () => {
-  const mockHandleFilter = jest.fn();
+  const mockFiltersProp = {
+    sortBy: 'test',
+    groupBy: 'test',
+    search: '',
+  };
+  const mockSetFilters = jest.fn();
+  const mockSetPage = jest.fn();
+  const getById = queryByAttribute.bind(null, 'id');
+
+  const renderTaskFilters = () => {
+    return render(
+      <TaskFilters
+        filters={{ ...mockFiltersProp }}
+        setFilters={mockSetFilters}
+        setPage={mockSetPage}
+        taskType="groups"
+      />
+    );
+  };
 
   beforeEach(() => {
-    mockHandleFilter.mockClear();
+    jest.clearAllMocks();
   });
 
   it('renders without crashing', () => {
-    shallow(
-      <TaskFilters search="" sortBy="test" groupBy="test" handleFilters={mockHandleFilter} />
-    );
+    renderTaskFilters();
   });
 
   it('calls handleFilter when sortBy option has been chosen', () => {
-    const wrapper = shallow(
-      <TaskFilters search="" sortBy="test" groupBy="test" handleFilters={mockHandleFilter} />
-    );
-    const sortBy = wrapper.find('select[id="sort"]').at(0);
+    const expectedResult = { ...mockFiltersProp, sortBy: 'desc-dueDate' };
+    const { container } = renderTaskFilters();
 
-    sortBy.simulate('change', { event: { target: { value: 'desc-dueDate' } } });
+    fireEvent.change(getById(container, 'sort'), { target: { value: 'desc-dueDate' } });
 
-    expect(mockHandleFilter).toHaveBeenCalled();
+    expect(mockSetFilters).toHaveBeenCalledWith(expectedResult);
   });
 
   it('calls handleFilter when groupBy option has been chosen', () => {
-    const wrapper = shallow(
-      <TaskFilters search="" sortBy="test" groupBy="test" handleFilters={mockHandleFilter} />
-    );
-    const groupBy = wrapper.find('select[id="group"]').at(0);
+    const expectedResult = { ...mockFiltersProp, groupBy: 'priority' };
+    const { container } = renderTaskFilters();
 
-    groupBy.simulate('change', { event: { target: { value: 'priority' } } });
+    fireEvent.change(getById(container, 'group'), { target: { value: 'priority' } });
 
-    expect(mockHandleFilter).toHaveBeenCalled();
+    expect(mockSetFilters).toHaveBeenCalledWith(expectedResult);
   });
 
   it('calls handleFilter when search bar has input', () => {
-    const wrapper = shallow(
-      <TaskFilters search="" sortBy="test" groupBy="test" handleFilters={mockHandleFilter} />
-    );
-    const searchBar = wrapper.find('input[id="filterTaskName"]').at(0);
+    const expectedResult = { ...mockFiltersProp, search: 'Border' };
+    const { container } = renderTaskFilters();
 
-    searchBar.simulate('change', { event: { target: { value: 'Border' } } });
+    fireEvent.change(getById(container, 'filterTaskName'), { target: { value: 'Border' } });
 
-    expect(mockHandleFilter).toHaveBeenCalled();
+    expect(mockSetFilters).toHaveBeenCalledWith(expectedResult);
   });
 });


### PR DESCRIPTION
### AC
When a user filters the task list by sort or search, the task list returned should start at page index of 0. When filtering by groups, the page index should remain the same.

### Updated
- Moved task filtering logic into `TaskFilters` component (not inc. the api call made as a result)
- Split the filtering out from 1 function into 3 separate ones for clarity and to handle specific scenarios required for each filter type
- Updated tests to reflect changes

### Notes
To verify for testing, have the network tab open and double check that network requests are only made for both sort and search but NOT for groups

### To test
- Pull and run cop locally pointing the proxy to the dev environment
- Login
- Navigate to `/tasks`
- Click 'Next' on the pagination buttons at the bottom of the list
- *You should be taken to next page of tasks*
- Change the sorting to something different than it is already on
- *New list of tasks should be rendered*
- *You should the `First` and `Previous` buttons disabled*
- Click 'Next' on the pagination buttons at the bottom of the list
- Change grouping to something different than what is already on
- *Same list of tasks should be grouped accordingly*
- *You should be on the same task list page - buttons not disabled that were disabled before*
- Search for a task by name
- *New list of tasks should be rendered*
- *You should the `First` and `Previous` buttons disabled*