### PR TITLE
Strip quote marks from Case Search input

### DIFF
--- a/client/public/locales/en-GB/translation.json
+++ b/client/public/locales/en-GB/translation.json
@@ -54,7 +54,7 @@
       "title": "Cases",
       "caption": "Case view",
       "heading": "Cases",
-      "heading-help": "Enter a COP number in quotes to search for cases—e.g. \"COP-20200406-24\".",
+      "heading-help": "Enter a COP number to search for cases, e.g. COP-20200406-24.",
       "heading-warning": "Please note all actions are audited.",
       "search-placeholder": "Search using a COP prefixed number",
       "search-message": "Searching for cases...",

--- a/client/src/pages/cases/CasePage.jsx
+++ b/client/src/pages/cases/CasePage.jsx
@@ -103,7 +103,8 @@ const CasePage = ({ caseId }) => {
           <div className="govuk-form-group">
             <input
               onChange={(e) => {
-                findCases(e.target.value);
+                const strippedInput = e.target.value.replace(/"/g, '');
+                findCases(strippedInput);
               }}
               spellCheck="false"
               className="govuk-input search__input"


### PR DESCRIPTION
### Description

This branch updates the search functionality for Cases by stripping any " symbols from the search string. This is because the v2 Cases API throws a 500 if you search using a search term with unclosed double quotes e.g. "COP-123 ... 

On v1, users are guided to search using double quotes as this is what the old engine required. No quotes are required on v2 to return the correct cases but users will likely be used to searching in this way, so here we add in logic to strip out all " from the search input to avoid returning 500 errors. 

Also updated the hint to remove reference to searching with quote marks. 


### To test:
- Run locally and point proxy to dev. 
- Navigate to Cases page and try to search for a case with double quotes in. You should see no errors.