### PR TITLE
Use customValidation instead of beforeSubmit hook

### DIFF
--- a/client/src/components/form/DisplayForm.jsx
+++ b/client/src/components/form/DisplayForm.jsx
@@ -330,7 +330,7 @@ const DisplayForm = ({
             buttonSettings: {
               showCancel: true,
             },
-            beforeSubmit: (submissionData, next) => {
+            customValidation: (submissionData, next) => {
               /* eslint-disable no-param-reassign, no-shadow */
               const { versionId, id, title, name } = form;
               submissionData.data.form = {

--- a/client/src/components/form/DisplayForm.test.jsx
+++ b/client/src/components/form/DisplayForm.test.jsx
@@ -146,7 +146,7 @@ describe('DisplayForm', () => {
       },
     };
 
-    form.props().options.hooks.beforeSubmit(submission, next);
+    form.props().options.hooks.customValidation(submission, next);
     /*
      * Could check for object equality however the form object has dynamic values that may
      * change throughout the test


### PR DESCRIPTION
If we try to perform validation that depends on certain context objects which are removed when the form is submitted, we run into a problem when the `beforeSubmit` hook is used in that they are removed before the validation occurs. If we instead use the `customValidation` hook then these objects are removed _after_ validation occurs, getting around the problem.