### PR TITLE
COP-5904 Add token expiration handler

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -41,6 +41,7 @@ const keycloakInstance = new Keycloak({
 });
 const keycloakProviderInitConfig = {
   onLoad: 'login-required',
+  checkLoginIframe: false,
 };
 
 const RouterView = () => {
@@ -50,6 +51,18 @@ const RouterView = () => {
   initAll();
   useFetchTeam();
   useFetchStaffId();
+
+  keycloak.onTokenExpired = () => {
+    console.log('refreshing token');
+    keycloak
+      .updateToken()
+      .then(() => {
+        console.log('token refreshed');
+      })
+      .catch(() => {
+        keycloak.logout();
+      });
+  };
 
   const tracker = createInstance({
     urlBase: config.get('analyticsUrlBase'),

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -41,7 +41,6 @@ const keycloakInstance = new Keycloak({
 });
 const keycloakProviderInitConfig = {
   onLoad: 'login-required',
-  checkLoginIframe: false,
 };
 
 const RouterView = () => {


### PR DESCRIPTION
### AC
When a user is using COP, the keycloak token used for axios requests shall remain valid for as long as the refreshToken permits. When the refreshToken is no longer valid, the user should be logged out gracefully. 

### Updated
- Added `onTokenExpired` listener `App.jsx`, this listens for when the token expires then executes the custom function assigned to it. 

### Notes
- When the refreshToken is no longer valid (when the token can no longer be updated), the `catch` should be triggered and the user logged out

### To test
- Pull and run cop locally pointing proxy to dev environment
- Login
- Open network tab in dev tools
- Refresh page
- *You should see a `token` request made in the network tab*
- Wait for the amount of time the current token is valid for (env dependent), occasionally registering activity on your machine (to prevent dev server disconnecting)
- *You should see a second `token` request  in the network tab*
- Click on a task list panel on the dashboard
- *You should successfully be taken to the page without error*
- After this time, wait for amount of time the refresh token is valid for (env dependent) in order to allow for the refresh token to expire
- *You should be logged out gracefully*