### PR TITLE
COP-5750 - ManDec: Cannot find 'startDeclaration' on COPv2

### DIFF
--- a/client/src/components/form/hooks.js
+++ b/client/src/components/form/hooks.js
@@ -5,6 +5,7 @@ import { useNavigation } from 'react-navi';
 import { useAxios } from '../../utils/hooks';
 import { AlertContext } from '../../utils/AlertContext';
 import SecureLocalStorageManager from '../../utils/SecureLocalStorageManager';
+import { variableInputFieldKey } from '../../utils/constants';
 
 export default () => {
   const axiosInstance = useAxios();
@@ -13,6 +14,10 @@ export default () => {
   const navigation = useNavigation();
   const [keycloak] = useKeycloak();
   const currentUser = keycloak.tokenParsed.email;
+  const formName = ({ components, name }) => {
+    const variableInput = components.find((c) => c.key === variableInputFieldKey);
+    return variableInput ? variableInput.defaultValue : name;
+  };
 
   const submitForm = useCallback(
     ({
@@ -27,7 +32,7 @@ export default () => {
     }) => {
       if (form) {
         const variables = {
-          [form.name]: {
+          [formName(form)]: {
             value: JSON.stringify(submission.data),
             type: 'json',
           },
@@ -77,5 +82,6 @@ export default () => {
 
   return {
     submitForm,
+    formName,
   };
 };

--- a/client/src/components/form/hooks.js
+++ b/client/src/components/form/hooks.js
@@ -5,7 +5,7 @@ import { useNavigation } from 'react-navi';
 import { useAxios } from '../../utils/hooks';
 import { AlertContext } from '../../utils/AlertContext';
 import SecureLocalStorageManager from '../../utils/SecureLocalStorageManager';
-import { variableInputFieldKey } from '../../utils/constants';
+import { formSubmitPath, variableInputFieldKey } from '../../utils/constants';
 
 export default () => {
   const axiosInstance = useAxios();
@@ -17,6 +17,9 @@ export default () => {
   const formName = ({ components, name }) => {
     const variableInput = components.find((c) => c.key === variableInputFieldKey);
     return variableInput ? variableInput.defaultValue : name;
+  };
+  const businessKeyValue = (submitPath, businessKey) => {
+    return submitPath === formSubmitPath ? businessKey : undefined;
   };
 
   const submitForm = useCallback(
@@ -45,7 +48,7 @@ export default () => {
         axiosInstance
           .post(`/camunda/engine-rest/${submitPath}/${id}/submit-form`, {
             variables,
-            businessKey,
+            businessKey: businessKeyValue(submitPath, businessKey),
           })
           .then(async () => {
             axiosInstance
@@ -83,5 +86,6 @@ export default () => {
   return {
     submitForm,
     formName,
+    businessKeyValue,
   };
 };

--- a/client/src/components/form/hooks.test.jsx
+++ b/client/src/components/form/hooks.test.jsx
@@ -5,6 +5,7 @@ import MockAdapter from 'axios-mock-adapter';
 import { AlertContextProvider } from '../../utils/AlertContext';
 import apiHooks from './hooks';
 import { mockNavigate } from '../../setupTests';
+import { formSubmitPath, taskSubmitPath } from '../../utils/constants';
 
 jest.mock('../../utils/logger', () => ({
   error: jest.fn(),
@@ -320,6 +321,20 @@ describe('hooks - can submit a form from a task', () => {
         name: 'manDec',
       });
       expect(formNameResult).toEqual('manDec');
+    });
+  });
+
+  describe('businessKeyValue', () => {
+    const testBusinessKey = 'COP-20200414-824';
+
+    it('sets the business key value for forms', () => {
+      const businessKeyResult = result.current.businessKeyValue(formSubmitPath, testBusinessKey);
+      expect(businessKeyResult).toEqual(testBusinessKey);
+    });
+
+    it('sets an undefined business key value for tasks', () => {
+      const businessKeyResult = result.current.businessKeyValue(taskSubmitPath, testBusinessKey);
+      expect(businessKeyResult).toEqual(undefined);
     });
   });
 });

--- a/client/src/components/form/hooks.test.jsx
+++ b/client/src/components/form/hooks.test.jsx
@@ -45,7 +45,7 @@ describe('hooks - can submit a form from a new form instance', () => {
       submitAgain: true,
     },
   };
-  const form = { name: 'test', id: 'formId' };
+  const form = { name: 'test', id: 'formId', components: { find: () => false } };
   const id = 'formId';
   const businessKey = 'businessKey';
   const handleOnFailure = jest.fn();
@@ -205,7 +205,7 @@ describe('hooks - can submit a form from a task', () => {
       },
     },
   };
-  const form = { name: 'test', id: 'formId' };
+  const form = { name: 'test', id: 'formId', components: { find: () => false } };
   const id = 'taskId';
   const businessKey = 'businessKey';
   const handleOnFailure = jest.fn();
@@ -303,5 +303,23 @@ describe('hooks - can submit a form from a task', () => {
       });
     });
     expect(mockNavigate).toHaveBeenCalledWith('/');
+  });
+
+  describe('formName', () => {
+    it('sets the correct form name when the submitVariableName field is present', () => {
+      const formNameResult = result.current.formName({
+        components: [{ key: 'submitVariableName', defaultValue: 'submitDeclarations' }],
+        name: 'manDec',
+      });
+      expect(formNameResult).toEqual('submitDeclarations');
+    });
+
+    it('sets the correct form name when the submitVariableName field is not present', () => {
+      const formNameResult = result.current.formName({
+        components: [],
+        name: 'manDec',
+      });
+      expect(formNameResult).toEqual('manDec');
+    });
   });
 });

--- a/client/src/pages/forms/FormPage.jsx
+++ b/client/src/pages/forms/FormPage.jsx
@@ -10,6 +10,7 @@ import { useAxios, useIsMounted } from '../../utils/hooks';
 import ApplicationSpinner from '../../components/ApplicationSpinner';
 import apiHooks from '../../components/form/hooks';
 import DisplayForm from '../../components/form/DisplayForm';
+import { formSubmitPath } from '../../utils/constants';
 import './Forms.scss';
 
 const FormPage = ({ formId }) => {
@@ -128,7 +129,7 @@ const FormPage = ({ formId }) => {
             businessKey: businessKeyComponent ? businessKeyComponent.defaultValue : null,
             handleOnFailure,
             handleOnRepeat,
-            submitPath: 'process-definition/key',
+            submitPath: formSubmitPath,
             localStorageReference,
           });
         }}

--- a/client/src/pages/tasks/TaskPage.jsx
+++ b/client/src/pages/tasks/TaskPage.jsx
@@ -11,6 +11,7 @@ import ApplicationSpinner from '../../components/ApplicationSpinner';
 import DisplayForm from '../../components/form/DisplayForm';
 import apiHooks from '../../components/form/hooks';
 import TaskPageSummary from './components/TaskPageSummary';
+import { taskSubmitPath } from '../../utils/constants';
 
 const TaskPage = ({ taskId }) => {
   const isMounted = useIsMounted();
@@ -178,7 +179,7 @@ const TaskPage = ({ taskId }) => {
                   businessKey: processInstance.businessKey,
                   handleOnFailure,
                   handleOnRepeat,
-                  submitPath: 'task',
+                  submitPath: taskSubmitPath,
                 });
               }}
             />

--- a/client/src/utils/constants.js
+++ b/client/src/utils/constants.js
@@ -11,3 +11,5 @@ export const powerBIBranchNames = [
 ];
 
 export const powerBiSchema = 'http://powerbi.com/product/schema#basic';
+
+export const variableInputFieldKey = 'submitVariableName';

--- a/client/src/utils/constants.js
+++ b/client/src/utils/constants.js
@@ -1,3 +1,5 @@
+export const formSubmitPath = 'process-definition/key';
+
 export const mobileWidth = 640;
 
 export const powerBIBranchNames = [
@@ -11,5 +13,7 @@ export const powerBIBranchNames = [
 ];
 
 export const powerBiSchema = 'http://powerbi.com/product/schema#basic';
+
+export const taskSubmitPath = 'task';
 
 export const variableInputFieldKey = 'submitVariableName';


### PR DESCRIPTION
**Intro**

This PR contains 3 commits to fix 2 issues with the Man Dec process. The 2 issues are that the form data can't be found in the process which is fixed by commit 1 and that the encryption of task data is failing which is fixed by commit 3. Commit 2 is a task to tidy the submit paths so they can be better reused in commit 3.

**1. Update submitForm hook to make the key for the form data in the payload dynamic**
    
This follows what is done in V1 and enables the form data in the payload to be named differently from the form name by checking if a submitVariableName hidden field is present in the form and if so then using it's value as the data key rather than the form name.
    
This gives us the ability to use the form name for other things such as form versioning, which was started to be done in Man Dec but not fully used.

**2. Move submitPath in FormPage and TaskPage to the constants**
    
These values can then be more easily changed and used in other places.

**3. Update submitForm hook to only send businessKey in the payload for forms**
    
It's not necessary to send businessKey in the payload for tasks because the process has already started at this point and the business key is already defined.
    
This is required by Man Dec because the encryption function for task data is expecting a specific payload in the form of a camunda task object which doesn't include businessKey.