### PR TITLE
COP-6752: Update tasks assigned to you page to be same as v1

### DIFF
--- a/client/src/pages/tasks/TasksListPage.jsx
+++ b/client/src/pages/tasks/TasksListPage.jsx
@@ -215,6 +215,7 @@ const TasksListPage = ({ taskType }) => {
             <div className="govuk-grid-column-full">
               <TaskList
                 tasks={data.tasks}
+                taskType={taskType}
                 groupBy={filters.groupBy}
                 areTasksLoading={areTasksLoading}
               />

--- a/client/src/pages/tasks/components/TaskList.jsx
+++ b/client/src/pages/tasks/components/TaskList.jsx
@@ -5,7 +5,7 @@ import _ from 'lodash';
 import TaskListItem from './TaskListItem';
 import determinePriority from '../../../utils/priority';
 
-const TaskList = ({ tasks, groupBy }) => {
+const TaskList = ({ tasks, groupBy, taskType }) => {
   const tasksGroupedBy = _.groupBy(tasks, (x) => x[groupBy]);
   const isPriority = (keyName) => {
     if (groupBy === 'priority') {
@@ -37,6 +37,7 @@ const TaskList = ({ tasks, groupBy }) => {
                     key={task.id}
                     id={task.id}
                     due={task.due}
+                    taskType={taskType}
                     name={task.name}
                     assignee={task.assignee}
                     businessKey={task.businessKey}
@@ -63,6 +64,7 @@ TaskList.propTypes = {
     })
   ),
   groupBy: PropTypes.string.isRequired,
+  taskType: PropTypes.string.isRequired,
 };
 
 export default TaskList;

--- a/client/src/pages/tasks/components/TaskList.test.jsx
+++ b/client/src/pages/tasks/components/TaskList.test.jsx
@@ -5,7 +5,7 @@ import TaskList from './TaskList';
 
 describe('TaskList', () => {
   it('renders without crashing', () => {
-    shallow(<TaskList groupBy="category" />);
+    shallow(<TaskList groupBy="category" taskType="groups" />);
   });
 
   it('can click on a task', () => {
@@ -20,6 +20,7 @@ describe('TaskList', () => {
           },
         ]}
         groupBy="category"
+        taskType="groups"
       />
     );
 

--- a/client/src/pages/tasks/components/TaskListItem.jsx
+++ b/client/src/pages/tasks/components/TaskListItem.jsx
@@ -11,7 +11,7 @@ import { isOverDue } from './utils';
 
 dayjs.extend(relativeTime);
 
-const TaskListItem = ({ id, due, name, assignee, businessKey }) => {
+const TaskListItem = ({ id, due, name, assignee, businessKey, taskType }) => {
   const axiosInstance = useAxios();
   const [keycloak] = useKeycloak();
   const navigation = useNavigation();
@@ -81,13 +81,36 @@ const TaskListItem = ({ id, due, name, assignee, businessKey }) => {
       </div>
       <div className="govuk-grid-column-one-half">
         <div className="govuk-grid-row">
-          <div className="govuk-grid-column-one-third govuk-!-margin-bottom-3">
-            {isOverDue(due)}
-          </div>
-          <div className="govuk-grid-column-one-third govuk-!-margin-bottom-3">
-            <span className="govuk-!-font-size-19 govuk-!-font-weight-bold">{isAssigned()}</span>
-          </div>
-          <div className="govuk-grid-column-one-third claim-task">{canClaimTask()}</div>
+          {taskType === 'groups' && (
+            <>
+              <div className="govuk-grid-column-one-third govuk-!-margin-bottom-3">
+                {isOverDue(due)}
+              </div>
+              <div className="govuk-grid-column-one-third govuk-!-margin-bottom-3">
+                <span className="govuk-!-font-size-19 govuk-!-font-weight-bold">
+                  {isAssigned()}
+                </span>
+              </div>
+              <div className="govuk-grid-column-one-third claim-task">{canClaimTask()}</div>
+            </>
+          )}
+          {taskType === 'yours' && (
+            <>
+              <div className="govuk-grid-column-two-thirds govuk-!-margin-bottom-3">
+                {isOverDue(due)}
+              </div>
+              <div className="govuk-grid-column-one-third claim-task">
+                <button
+                  type="submit"
+                  id="actionButton"
+                  className="govuk-button"
+                  onClick={handleClaim}
+                >
+                  Action
+                </button>
+              </div>
+            </>
+          )}
         </div>
       </div>
     </div>
@@ -104,6 +127,7 @@ TaskListItem.propTypes = {
   name: PropTypes.string.isRequired,
   assignee: PropTypes.string,
   businessKey: PropTypes.string.isRequired,
+  taskType: PropTypes.string.isRequired,
 };
 
 export default TaskListItem;

--- a/client/src/pages/tasks/components/TaskListItem.test.jsx
+++ b/client/src/pages/tasks/components/TaskListItem.test.jsx
@@ -16,13 +16,27 @@ describe('TaskListItem', () => {
 
   it('can render without error', () => {
     shallow(
-      <TaskListItem id="1" due="2020/03/19" name="test" assignee="test" businessKey="test" />
+      <TaskListItem
+        id="1"
+        due="2020/03/19"
+        name="test"
+        assignee="test"
+        businessKey="test"
+        taskType="groups"
+      />
     );
   });
 
   it('can click on a task', () => {
     const wrapper = mount(
-      <TaskListItem id="1" due="2020/03/19" name="test" assignee="test" businessKey="test" />
+      <TaskListItem
+        id="1"
+        due="2020/03/19"
+        name="test"
+        assignee="test"
+        businessKey="test"
+        taskType="groups"
+      />
     );
 
     expect(wrapper.find(Link).at(0).props().href).toBe('/tasks/1');
@@ -30,7 +44,14 @@ describe('TaskListItem', () => {
 
   it('renders "Overdue" if task due date is in the past', () => {
     const wrapper = mount(
-      <TaskListItem id="1" due="2020/03/19" name="test" assignee="test" businessKey="test" />
+      <TaskListItem
+        id="1"
+        due="2020/03/19"
+        name="test"
+        assignee="test"
+        businessKey="test"
+        taskType="groups"
+      />
     );
     const taskDue = wrapper
       .find('div[className="govuk-grid-column-one-third govuk-!-margin-bottom-3"]')
@@ -42,7 +63,14 @@ describe('TaskListItem', () => {
   it('renders "Due" if task due date is in the future', () => {
     const tomorrow = dayjs().add(1, 'day').format();
     const wrapper = mount(
-      <TaskListItem id="1" due={tomorrow} name="test" assignee="test" businessKey="test" />
+      <TaskListItem
+        id="1"
+        due={tomorrow}
+        name="test"
+        assignee="test"
+        businessKey="test"
+        taskType="groups"
+      />
     );
     const taskDue = wrapper
       .find('div[className="govuk-grid-column-one-third govuk-!-margin-bottom-3"]')
@@ -62,6 +90,7 @@ describe('TaskListItem', () => {
         due="2020/03/19"
         name="testName"
         assignee="testAssignee"
+        taskType="groups"
         businessKey="testKey"
       />
     );
@@ -81,7 +110,14 @@ describe('TaskListItem', () => {
     });
     // In the setupTests mocks, the default current user is "test"
     render(
-      <TaskListItem id="1" due="2020/03/19" name="testName" assignee="test" businessKey="testKey" />
+      <TaskListItem
+        id="1"
+        due="2020/03/19"
+        name="testName"
+        assignee="test"
+        businessKey="testKey"
+        taskType="groups"
+      />
     );
 
     expect(screen.getByText('Unclaim')).toBeTruthy();

--- a/client/src/pages/tasks/components/TaskListItem.test.jsx
+++ b/client/src/pages/tasks/components/TaskListItem.test.jsx
@@ -104,6 +104,31 @@ describe('TaskListItem', () => {
     });
   });
 
+  it('can action a task from the tasks assigned to you page', async () => {
+    mockAxios.onPost('/camunda/engine-rest/task/1/assignee').reply(200, {
+      count: 1,
+    });
+    // In the setupTests mocks, the default current user is "test"
+    render(
+      <TaskListItem
+        id="1"
+        due="2020/03/19"
+        name="testName"
+        assignee="testAssignee"
+        taskType="yours"
+        businessKey="testKey"
+      />
+    );
+
+    expect(screen.getByText('Action')).toBeTruthy();
+
+    fireEvent.click(screen.getByText('Action'));
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith('/tasks/1');
+    });
+  });
+
   it('can unclaim a task assigned to the current user', async () => {
     mockAxios.onPost('/camunda/engine-rest/task/1/unclaim').reply(200, {
       count: 1,


### PR DESCRIPTION
This branch updates the "Tasks Assigned to you" page to reflect the format of V1. Full details of the discrepancy are found here: https://support.cop.homeoffice.gov.uk/browse/COP-6752

**To Test:**

- pull and run locally pointing proxy to dev
- navigate to "Tasks assigned to you page" via the dashboard. If you don't have any tasks you'll need to create one (complete a Record Border Event form to trigger task)
- You should now see an "Action" button rather than Claim/Unclaim and the page should now look the same as V1
-  Clicking Action will take you to the Task Page where you can complete the task