### PR TITLE
COP-7229: Add temp fix to set team equal to currentGroup in shiftDetailsContext

### DIFF
--- a/client/src/components/form/DisplayForm.jsx
+++ b/client/src/components/form/DisplayForm.jsx
@@ -116,7 +116,7 @@ const DisplayForm = ({
         locationid: String(defaultlocationid),
         phone,
         roles,
-        team,
+        team: currentGroup,
         teamid,
         currentGroup,
         groups,

--- a/client/src/pages/cases/components/CaseAction.jsx
+++ b/client/src/pages/cases/components/CaseAction.jsx
@@ -8,6 +8,7 @@ import { useAxios, useIsMounted } from '../../../utils/hooks';
 import { TeamContext } from '../../../utils/TeamContext';
 import { StaffIdContext } from '../../../utils/StaffIdContext';
 import FileService from '../../../utils/FileService';
+import { CurrentGroupContext } from '../../../utils/CurrentGroupContext';
 
 Formio.use(gds);
 
@@ -66,6 +67,7 @@ const CaseAction = ({
 
   const { team } = useContext(TeamContext);
   const { staffId: staffid } = useContext(StaffIdContext);
+  const { currentGroup } = useContext(CurrentGroupContext);
 
   const contexts = {
     data: {
@@ -105,9 +107,10 @@ const CaseAction = ({
         locationid: String(defaultlocationid),
         phone,
         roles,
-        team,
+        team: currentGroup,
         teamid,
         groups,
+        currentGroup,
       },
       staffDetailsDataContext: {
         adelphi,


### PR DESCRIPTION
This branch updates the `shiftDetailsContext` object which is used to append data onto the form submissions that are subsequently used in the BPMNs. It changes the `team` value to be equal to the `currentGroup`. This change is a temporary fix to avoid having to change a large number of BPMNs which are currently set to look for shiftDetailsContext.team.code, so instead team.code will now be equal to currentGroup.code. 

**To test**
- run locally and point the proxy to dev
- you need to have multiple groups associated with your profile to test fully.
- On the dashboard, change your current group to something else other than the one you logged in as (i.e. not your default team). 
- Go to Forms list page and complete a Collect Event at Border up until a task is triggered. 
- Navigate back to the dashboard and look at tasks and you will see that this has assigned the task to the current group you specified on your dashboard. 
