### PR TITLE
COP-7110: COP v2 showing blank page [local storage issue]

### DIFF
--- a/client/src/utils/CurrentGroupContext.jsx
+++ b/client/src/utils/CurrentGroupContext.jsx
@@ -1,6 +1,5 @@
 import React, { createContext, useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
-import SecureLocalStorageManager from './SecureLocalStorageManager';
 
 export const CurrentGroupContext = createContext({
   currentGroup: undefined,
@@ -10,12 +9,17 @@ export const CurrentGroupContext = createContext({
 });
 
 export const CurrentGroupContextProvider = ({ children }) => {
-  const [currentGroup, setCurrentGroup] = useState(SecureLocalStorageManager.get('currentGroup'));
+  const [currentGroup, setCurrentGroupState] = useState(undefined);
   const [groupLoaded, setGroupLoaded] = useState(false);
 
+  const setCurrentGroup = (group) => {
+    localStorage.setItem('currentGroup', JSON.stringify(group));
+    setCurrentGroupState(group);
+  };
+
   useEffect(() => {
-    SecureLocalStorageManager.set('currentGroup', currentGroup);
-  }, [currentGroup]);
+    setCurrentGroup(JSON.parse(localStorage.getItem('currentGroup')));
+  }, []);
 
   return (
     <CurrentGroupContext.Provider

--- a/client/src/utils/hooks.js
+++ b/client/src/utils/hooks.js
@@ -132,6 +132,10 @@ export const useFetchCurrentGroup = () => {
             const response = await axiosInstance.get(
               `refdata/v2/entities/groups?filter=teamid=eq.${teamid}`,
               {
+                params: {
+                  select:
+                    'id,displayname,code,grouptypeid,branchid,keycloakgrouppath,locationid,name,selfmanaged,teamid',
+                },
                 cancelToken: source.token,
               }
             );
@@ -168,7 +172,8 @@ export const useFetchGroups = () => {
             const response = await axiosInstance.get('refdata/v2/entities/groups', {
               params: {
                 mode: 'dataOnly',
-                select: 'displayname,code,grouptypeid',
+                select:
+                  'id,displayname,code,grouptypeid,branchid,keycloakgrouppath,locationid,name,selfmanaged,teamid',
                 filter: `keycloakgrouppath=in.(${allUserGroups})`,
               },
             });


### PR DESCRIPTION
This branch updates the Current Group context to store the currentGroup in local storage, rather that secure local storage. This is to fix a bug where by the encryption/decrytion of the current group object was cause V2 UI to break in certain circumstances. 

**To test:**
- run v2 locally with proxy pointing to dev
1. Submit the Report a Variance form
2. Go to tasks and click "Action" on the newly created one
3. Click the link on the first page of the form: 
"To complete this form, you will need to review the case history (opens in new tab)."
4. Navigate back to first window and complete the form
5. Go back to task list, click on Action on the OTHER task the workflow triggered.
6. Click the link on the first page: "To complete this form, you will need to review the case history (opens in new tab)."
7. New browser page will no longer break and everything should continue to work. 

