### PR TITLE
COP-7382: Change no team set error message

### DIFF
--- a/client/public/locales/en-GB/translation.json
+++ b/client/public/locales/en-GB/translation.json
@@ -204,7 +204,10 @@
       }
     },
     "groups": {
-      "user-has-no-group": "Your Team is not set on your profile yet. Please contact COP support to add your Team.",
+      "error-heading": "No team added to your profile",
+      "user-has-no-group": "You need to have your team added to your profile to use the Central Operations Platform.",
+      "support-link":"Go to IT Now ",
+      "support-link-message": "to tell us which team you’re in and we'll add it to your profile.",
       "select-group": "Select Team",
       "save-group": "Save",
       "change-group": "change"

--- a/client/src/pages/home/index.jsx
+++ b/client/src/pages/home/index.jsx
@@ -139,20 +139,21 @@ const Home = () => {
   }
   if (groupLoaded && !currentGroup) {
     return (
-      <div
-        className="govuk-error-summary"
-        aria-labelledby="error-summary-title"
-        role="alert"
-        tabIndex="-1"
-        data-module="govuk-error-summary"
-      >
-        <h2 className="govuk-error-summary__title" id="error-summary-title">
-          {t('pages.form.error.form.title')}
-        </h2>
-        <div className="govuk-error-summary__body">
-          <ul className="govuk-list govuk-error-summary__list">
-            <li>{t('pages.groups.user-has-no-group')}</li>
-          </ul>
+      <div className="govuk-grid-row govuk-!-margin-top-7">
+        <div className="govuk-grid-column-two-thirds">
+          <h1 className="govuk-heading-l">{t('pages.groups.error-heading')}</h1>
+          <p className="govuk-body">{t('pages.groups.user-has-no-group')}</p>
+          <p className="govuk-body">
+            <a
+              href="https://lssiprod.service-now.com/ess"
+              className="govuk-link"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              {t('pages.groups.support-link')}
+            </a>
+            {t('pages.groups.support-link-message')}
+          </p>
         </div>
       </div>
     );


### PR DESCRIPTION
This branch changes the error message for when a user doesn't have a team set up on keycloak telling them how to reach support link.

To test:
- delete your team on my profile page (or via keycloak)
- log out and in again. You should see the correct error message. You will then have to add your team back in (ask me or dev ops to do this)