### PR TITLE
Handle 'cancel-form' custom event

### DIFF
--- a/client/src/components/form/DisplayForm.jsx
+++ b/client/src/components/form/DisplayForm.jsx
@@ -23,6 +23,7 @@ Formio.use(gds);
 const DisplayForm = ({
   form,
   handleOnCancel,
+  handleOnCustomEvent,
   handleOnSubmit,
   interpolateContext,
   submitting,
@@ -309,6 +310,7 @@ const DisplayForm = ({
             metadata: data.metadata,
           });
         }}
+        onCustomEvent={(e) => handleOnCustomEvent(e)}
         onError={(errors) => {
           window.scrollTo(0, 0);
           setErrorAlert({
@@ -375,6 +377,7 @@ DisplayForm.propTypes = {
     components: PropTypes.arrayOf(PropTypes.object).isRequired,
   }).isRequired,
   handleOnCancel: PropTypes.func.isRequired,
+  handleOnCustomEvent: PropTypes.func.isRequired,
   handleOnSubmit: PropTypes.func.isRequired,
   interpolateContext: PropTypes.shape({ taskContext: PropTypes.shape() }),
   submitting: PropTypes.bool,

--- a/client/src/components/form/DisplayForm.test.jsx
+++ b/client/src/components/form/DisplayForm.test.jsx
@@ -26,6 +26,7 @@ describe('DisplayForm', () => {
         form={testData.formData}
         submitting
         handleOnCancel={jest.fn()}
+        handleOnCustomEvent={jest.fn()}
         handleOnSubmit={jest.fn()}
       />
     );
@@ -46,6 +47,7 @@ describe('DisplayForm', () => {
         form={testData.formData}
         submitting
         handleOnCancel={jest.fn()}
+        handleOnCustomEvent={jest.fn()}
         handleOnSubmit={jest.fn()}
       />
     );
@@ -64,6 +66,7 @@ describe('DisplayForm', () => {
         form={testData.formData}
         submitting
         handleOnCancel={jest.fn()}
+        handleOnCustomEvent={jest.fn()}
         handleOnSubmit={jest.fn()}
       />
     );
@@ -93,6 +96,7 @@ describe('DisplayForm', () => {
         form={testData.formData}
         submitting
         handleOnCancel={jest.fn()}
+        handleOnCustomEvent={jest.fn()}
         handleOnSubmit={jest.fn()}
       />
     );
@@ -125,6 +129,7 @@ describe('DisplayForm', () => {
         form={testData.formData}
         submitting
         handleOnCancel={jest.fn()}
+        handleOnCustomEvent={jest.fn()}
         handleOnSubmit={mockHandleOnSubmit}
       />
     );

--- a/client/src/pages/forms/FormPage.jsx
+++ b/client/src/pages/forms/FormPage.jsx
@@ -116,6 +116,11 @@ const FormPage = ({ formId }) => {
         handleOnCancel={async () => {
           await navigation.navigate('/forms');
         }}
+        handleOnCustomEvent={({ type }) => {
+          if (type === 'cancel-form') {
+            navigation.navigate('/');
+          }
+        }}
         interpolateContext={{
           businessKey: businessKeyComponent ? businessKeyComponent.defaultValue : null,
         }}

--- a/client/src/pages/forms/FormPage.test.jsx
+++ b/client/src/pages/forms/FormPage.test.jsx
@@ -4,6 +4,7 @@ import MockAdapter from 'axios-mock-adapter';
 import { shallow, mount } from 'enzyme';
 import { act } from '@testing-library/react';
 import { Form } from 'react-formio';
+import { mockNavigate } from '../../setupTests';
 import { testData } from '../../utils/TestData';
 import ApplicationSpinner from '../../components/ApplicationSpinner';
 import FormPage from './FormPage';
@@ -42,6 +43,7 @@ describe('FormPage', () => {
 
   afterEach(() => {
     wrapper.unmount();
+    jest.clearAllMocks();
   });
 
   it('Should render without crashing', () => {
@@ -112,5 +114,21 @@ describe('FormPage', () => {
     expect(wrapper.find(ApplicationSpinner).exists()).toBe(false);
     expect(wrapper.find(Form).exists()).toBe(false);
     // src > components > alert > AlertBanner & ApiErrorAlert test that the alert banner is shown on a 404 error
+  });
+
+  it('Should navigate to dashboard on and only on cancel-form custom event', async () => {
+    mockFetchProcessName();
+    mockFetchForm();
+    wrapper = await mount(<FormPage formId={testData.formData.id} />);
+    await act(async () => {
+      await Promise.resolve(wrapper);
+      await new Promise((resolve) => setImmediate(resolve));
+      await wrapper.update();
+    });
+    const form = wrapper.find('Form');
+    form.props().onCustomEvent(new Event('cancel'));
+    expect(mockNavigate).not.toBeCalled();
+    form.props().onCustomEvent(new Event('cancel-form'));
+    expect(mockNavigate).toBeCalledWith('/');
   });
 });


### PR DESCRIPTION
User Profile form dispatches this event - when it does we should return the user to the dashboard.