### PR TITLE
COP-7449: Team group local storage is not restricted to the user

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -63,6 +63,7 @@ const RouterView = () => {
         console.log('token refreshed');
       })
       .catch(() => {
+        localStorage.removeItem('currentGroup');
         keycloak.logout();
       });
   };

--- a/client/src/components/header/Logout.jsx
+++ b/client/src/components/header/Logout.jsx
@@ -3,6 +3,7 @@ import SecureLocalStorageManager from '../../utils/SecureLocalStorageManager';
 
 const Logout = () => {
   SecureLocalStorageManager.removeAll();
+  localStorage.removeItem('currentGroup');
   const [keycloak] = useKeycloak();
   keycloak.logout({
     redirectUri: window.location.origin.toString(),


### PR DESCRIPTION
This branch adds function to clear currentGroup from local storage when a user logs out, or if keycloak refresh token fails and user is automatically logged out. 

This is to prevent a bug where a previous user's currentGroup persists in localstorage when a new user logs in.