### PR TITLE
Use direct link to User Profile form

### DIFF
--- a/client/src/components/header/index.jsx
+++ b/client/src/components/header/index.jsx
@@ -60,16 +60,7 @@ const Header = () => {
                 aria-label="Navigation menu"
               >
                 <li className="govuk-header__navigation-item">
-                  <a
-                    href="/forms/edit-your-profile"
-                    id="myprofile"
-                    className="govuk-header__link"
-                    onClick={async (e) => {
-                      e.preventDefault();
-                      toggleMenu(e);
-                      await navigation.navigate('/forms/edit-your-profile');
-                    }}
-                  >
+                  <a href="/forms/edit-your-profile" id="myprofile" className="govuk-header__link">
                     {t('header.my-profile')}
                   </a>
                 </li>

--- a/client/src/components/header/index.test.jsx
+++ b/client/src/components/header/index.test.jsx
@@ -18,10 +18,9 @@ describe('Header', () => {
     );
   });
 
-  it('can click my profile', () => {
+  it('has correct href for "My profile" link', () => {
     const wrapper = mount(<Header />);
-    wrapper.find('a[id="myprofile"]').at(0).simulate('click');
-    expect(mockNavigate).toBeCalledWith('/forms/edit-your-profile');
+    expect(wrapper.find('a[id="myprofile"]').prop('href')).toBe('/forms/edit-your-profile');
   });
   it('can click logout', () => {
     const wrapper = mount(<Header />);


### PR DESCRIPTION
We're avoiding using Navi for this link as we want COP to refresh so that a new Keycloak token is fetched for the user and they can more quickly see their details refreshed (as in V1).