### PR TITLE
COP-7244 - Operating Mandate - Append a Record in V2

### DIFF
--- a/client/src/pages/cases/components/CaseAction.test.jsx
+++ b/client/src/pages/cases/components/CaseAction.test.jsx
@@ -47,7 +47,7 @@ describe('Case Action component', () => {
   });
 
   it('should render form for case action', async () => {
-    mockAxios.onGet('/form/name/performIntelActionMvp').reply(200, { recordActionsFormData });
+    mockAxios.onGet('/form/name/performIntelActionMvp').reply(200, recordActionsFormData);
 
     wrapper = mount(
       <CaseAction
@@ -87,7 +87,7 @@ describe('Case Action component', () => {
   });
 
   it('should render completion message when form is submitted', async () => {
-    mockAxios.onGet('/form/name/performIntelActionMvp').reply(200, { recordActionsFormData });
+    mockAxios.onGet('/form/name/performIntelActionMvp').reply(200, recordActionsFormData);
 
     mockAxios
       .onPost(
@@ -127,7 +127,7 @@ describe('Case Action component', () => {
   });
 
   it('should render error message if submitting form throws error', async () => {
-    mockAxios.onGet('/form/name/performIntelActionMvp').reply(200, { recordActionsFormData });
+    mockAxios.onGet('/form/name/performIntelActionMvp').reply(200, recordActionsFormData);
 
     mockAxios
       .onPost(

--- a/client/src/pages/cases/utils/LatestFormDataPath.js
+++ b/client/src/pages/cases/utils/LatestFormDataPath.js
@@ -1,0 +1,9 @@
+const latestFormDataPath = (processInstances, formKey) => {
+  return processInstances
+    .map(({ formReferences }) => formReferences)
+    .reduce((acc, val) => acc.concat(val), [])
+    .sort((a, b) => (a.submissionDate < b.submissionDate ? -1 : 1))
+    .reduce((acc, { name: formName, dataPath }) => (formName === formKey ? dataPath : acc), '');
+};
+
+export default latestFormDataPath;

--- a/client/src/pages/cases/utils/LatestFormDataPath.test.js
+++ b/client/src/pages/cases/utils/LatestFormDataPath.test.js
@@ -1,0 +1,59 @@
+import latestFormDataPath from './LatestFormDataPath';
+
+describe('latestFormDataPath', () => {
+  it('sets the latest form data path if there is a single form and a single process instance', async () => {
+    const processInstances = [
+      {
+        formReferences: [
+          {
+            name: 'form1',
+            dataPath: 'form1DataPath1',
+            submissionDate: '2021-06-24T11:26:00.000Z',
+          },
+        ],
+      },
+    ];
+    const path = latestFormDataPath(processInstances, 'form1');
+    expect(path).toEqual('form1DataPath1');
+  });
+
+  it('sets the latest form data path with multiple forms and multiple process instances and out of order', async () => {
+    const processInstances = [
+      {
+        formReferences: [
+          {
+            name: 'form1',
+            dataPath: 'form1DataPath1',
+            submissionDate: '2021-06-24T11:26:00.000Z',
+          },
+          {
+            name: 'form2',
+            dataPath: 'form2DataPath1',
+            submissionDate: '2021-06-22T15:49:00.000Z',
+          },
+        ],
+      },
+      {
+        formReferences: [
+          {
+            name: 'form1',
+            dataPath: 'form1DataPath3',
+            submissionDate: '2021-06-25T11:26:00.000Z',
+          },
+          {
+            name: 'form1',
+            dataPath: 'form1DataPath2',
+            submissionDate: '2021-06-25T09:09:00.000Z',
+          },
+          {
+            name: 'form2',
+            dataPath: 'form2DataPath2',
+            submissionDate: '2021-06-22T18:12:00.000Z',
+          },
+        ],
+      },
+    ];
+    const path = latestFormDataPath(processInstances, 'form1');
+    expect(path).toEqual('form1DataPath3');
+  });
+});

--- a/client/src/utils/constants.js
+++ b/client/src/utils/constants.js
@@ -1,3 +1,5 @@
+export const caseActionFormPrepopulateKey = 'caseActionPrepopulate';
+
 export const formSubmitPath = 'process-definition/key';
 
 export const mobileWidth = 640;


### PR DESCRIPTION
This change adds the append a record functionality required by Operating Mandate.

It presents the Operating Mandate Request and Ncc Upate Review Date/Time forms as Case Actions in Case View pre-populated with the latest data and enables the user to make changes to the submitted data.

Once the changed data has been submitted the data is available to view in the Case History as a new form. This keeps a history of each of the submitted form payloads so it's possible to see what was changed, when and by who.

This append a record functionality is opt-in so it doesn't affect any existing Case Action forms.

This change also handles the Cancel button so the form is reset to its initial state.