### PR TITLE
COP-7139: Add in back to dashboard and back to forms link for accessibility

### DIFF
--- a/client/public/locales/en-GB/translation.json
+++ b/client/public/locales/en-GB/translation.json
@@ -117,7 +117,8 @@
         "search": "Search for a form",
         "search-placeholder": "Search form name",
         "search-hint": "Must be greater than 3 characters"
-      }
+      },
+      "back-link": "Back to forms" 
     },
     "home": {
       "title": "Central Operations Platform",

--- a/client/public/locales/en-GB/translation.json
+++ b/client/public/locales/en-GB/translation.json
@@ -2,7 +2,7 @@
   "keycloak": {
     "initialising": "Initialising single sign on"
   },
-  "back": "Back",
+  "back": "Back to dashboard",
   "loading": "Loading...",
   "submitting": "Submitting your form....",
   "warning": "Warning",

--- a/client/src/components/layout/index.jsx
+++ b/client/src/components/layout/index.jsx
@@ -80,10 +80,11 @@ const Layout = ({ children }) => {
                 {route.url.pathname !== '/' ? (
                   // eslint-disable-next-line jsx-a11y/anchor-is-valid
                   <a
-                    href="#"
+                    href="/"
+                    id="back-to-dashboard"
                     onClick={async (e) => {
                       e.preventDefault();
-                      await navigation.goBack();
+                      await navigation.navigate('/');
                     }}
                     className="govuk-back-link"
                   >

--- a/client/src/components/layout/index.test.jsx
+++ b/client/src/components/layout/index.test.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { shallow, mount } from 'enzyme';
 import Layout from './index';
 import Logger from '../../utils/logger';
-import { mockGoBack } from '../../setupTests';
+import { mockNavigate } from '../../setupTests';
 
 jest.mock('../../utils/logger', () => ({
   error: jest.fn(),
@@ -40,17 +40,8 @@ describe('Layout', () => {
   });
 
   it('can click on back button', () => {
-    const wrapper = shallow(
-      <Layout>
-        <div>Hello</div>
-      </Layout>
-    );
-    wrapper
-      .find('a')
-      .at(0)
-      .simulate('click', {
-        preventDefault: () => {},
-      });
-    expect(mockGoBack).toBeCalled();
+    const wrapper = mount(<Layout />);
+    wrapper.find('a[id="back-to-dashboard"]').simulate('click');
+    expect(mockNavigate).toBeCalledWith('/');
   });
 });

--- a/client/src/pages/forms/FormPage.jsx
+++ b/client/src/pages/forms/FormPage.jsx
@@ -108,6 +108,20 @@ const FormPage = ({ formId }) => {
 
   return (
     <>
+      <div>
+        {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
+        <a
+          href="#"
+          id="back-to-forms"
+          onClick={async (e) => {
+            e.preventDefault();
+            await navigation.navigate('/forms');
+          }}
+          className="govuk-back-link"
+        >
+          Back to forms
+        </a>
+      </div>
       <h1 className="govuk-heading-l">{pageHeading}</h1>
       <DisplayForm
         submitting={submitting}

--- a/client/src/pages/forms/FormPage.jsx
+++ b/client/src/pages/forms/FormPage.jsx
@@ -119,7 +119,7 @@ const FormPage = ({ formId }) => {
           }}
           className="govuk-back-link"
         >
-          Back to forms
+          {t('pages.forms.back-link')}
         </a>
       </div>
       <h1 className="govuk-heading-l">{pageHeading}</h1>

--- a/client/src/pages/forms/FormPage.test.jsx
+++ b/client/src/pages/forms/FormPage.test.jsx
@@ -131,4 +131,17 @@ describe('FormPage', () => {
     form.props().onCustomEvent(new Event('cancel-form'));
     expect(mockNavigate).toBeCalledWith('/');
   });
+
+  it('can click on back to forms button', async () => {
+    mockFetchProcessName();
+    mockFetchForm();
+    wrapper = await mount(<FormPage formId={testData.formData.id} />);
+    await act(async () => {
+      await Promise.resolve(wrapper);
+      await new Promise((resolve) => setImmediate(resolve));
+      await wrapper.update();
+    });
+    wrapper.find('a[id="back-to-forms"]').simulate('click');
+    expect(mockNavigate).toBeCalledWith('/forms');
+  });
 });


### PR DESCRIPTION
This branch adds in a "Back to forms" list link on an individual form page and changes the site wide back button to read "back to dashboard". This is to make the UI more accessible in-line with V1 as described in ticket COP-7139. It also updates the tests accordingly. 

*To test:*
- Run locally pointing at the dev proxy.
- Navigate to the Forms list page, you will see one link back to the Dashboard. Test this works as expected.
- Navigate to the Forms list page and then click on any form to start it. You will see a link at the top of the page back to the dashboard AND the forms page. Test both of these work as expected. 
- Tests updated for these changes (npm test)