### PR TITLE
COP-7650: Update Case History section so forms display in order with correct Latest label

### DIFF
--- a/client/src/pages/cases/components/FormDetails.jsx
+++ b/client/src/pages/cases/components/FormDetails.jsx
@@ -23,6 +23,10 @@ const FormDetails = ({ formReferences, businessKey }) => {
   const [submissionData, setSubmissionData] = useState(null);
   const [selectedFormInstance, setSelectedFormInstance] = useState(null);
 
+  // const sortFormReferenceses = formReferences.sort((a,b) => {
+  //   return new Date(b.submissionDate) - new Date(a.submissionDate)
+  // })
+
   const fetchForm = async (formName, formVersionId) => {
     if (axiosInstance) {
       try {
@@ -76,77 +80,86 @@ const FormDetails = ({ formReferences, businessKey }) => {
 
   return (
     <>
-      {formReferences.map((formInstance, index) => {
-        const formInstanceKey = `${formInstance.formVersionId}-${formInstance.submissionDate}`;
-        const selectedFormInstanceKey = selectedFormInstance
-          ? `${selectedFormInstance.formVersionId}-${selectedFormInstance.submissionDate}`
-          : null;
-        const isSelectedFormInstance = formInstanceKey === selectedFormInstanceKey;
-        return (
-          <React.Fragment key={formInstanceKey}>
-            <details key={formInstanceKey} className="govuk-details" data-module="govuk-details">
-              <summary className="govuk-details__summary">
-                <span className="govuk-details__summary-text">{formInstance.title}</span>
-              </summary>
-              <div className="govuk-details__text--no-border">
-                <dl className="govuk-summary-list govuk-summary-list--no-border">
-                  <div className="govuk-summary-list__row">
-                    <dt className="govuk-summary-list__key">Submitted by</dt>
-                    <dd className="govuk-summary-list__value">{formInstance.submittedBy}</dd>
-                  </div>
-                  <div className="govuk-summary-list__row">
-                    <dt className="govuk-summary-list__key">Submitted on</dt>
-                    <dd className="govuk-summary-list__value">
-                      {dayjs(formInstance.submissionDate).format('DD/MM/YYYY HH:mm')}
-                    </dd>
-                  </div>
-                  <div className="govuk-summary-list__row">
-                    <dt className="govuk-summary-list__key">
-                      <span className="govuk-tag">Latest</span>
-                    </dt>
-                    <dd className="govuk-summary-list__value">
-                      <button
-                        type="button"
-                        className="govuk-button"
-                        onClick={(e) => {
-                          e.preventDefault();
-                          setSelectedFormInstance(
-                            formInstanceKey !== selectedFormInstanceKey ? formInstance : null
-                          );
-                        }}
-                      >
-                        {isSelectedFormInstance ? 'Hide Details' : 'Show details'}
-                      </button>
-                      {form.isLoading && isSelectedFormInstance && (
-                        <h4 className="govuk-body">
-                          {t('pages.cases.details-panel.case-history.form-loading')}
-                        </h4>
-                      )}
-                      {!form.isLoading && isSelectedFormInstance && (
-                        <Form
-                          form={form.data}
-                          submission={{ data: submissionData }}
-                          options={{
-                            readOnly: true,
-                            noAlerts: true,
-                            buttonSettings: {
-                              showPrevious: true,
-                              showNext: true,
-                              showSubmit: false,
-                              showCancel: false,
-                            },
+      {formReferences
+        .sort((a, b) => {
+          return new Date(b.submissionDate) - new Date(a.submissionDate);
+        })
+        .map((formInstance, index) => {
+          const formInstanceKey = `${formInstance.formVersionId}-${formInstance.submissionDate}`;
+          const selectedFormInstanceKey = selectedFormInstance
+            ? `${selectedFormInstance.formVersionId}-${selectedFormInstance.submissionDate}`
+            : null;
+          const isSelectedFormInstance = formInstanceKey === selectedFormInstanceKey;
+          return (
+            <React.Fragment key={formInstanceKey}>
+              <details
+                key={formInstanceKey}
+                id={`form${index}`}
+                className="govuk-details"
+                data-module="govuk-details"
+              >
+                <summary className="govuk-details__summary">
+                  <span className="govuk-details__summary-text">{formInstance.title}</span>
+                </summary>
+                <div className="govuk-details__text--no-border">
+                  <dl className="govuk-summary-list govuk-summary-list--no-border">
+                    <div className="govuk-summary-list__row">
+                      <dt className="govuk-summary-list__key">Submitted by</dt>
+                      <dd className="govuk-summary-list__value">{formInstance.submittedBy}</dd>
+                    </div>
+                    <div className="govuk-summary-list__row">
+                      <dt className="govuk-summary-list__key">Submitted on</dt>
+                      <dd className="govuk-summary-list__value">
+                        {dayjs(formInstance.submissionDate).format('DD/MM/YYYY HH:mm')}
+                      </dd>
+                    </div>
+                    <div className="govuk-summary-list__row">
+                      <dt className="govuk-summary-list__key">
+                        {index === 0 ? <span className="govuk-tag">Latest</span> : null}
+                      </dt>
+                      <dd className="govuk-summary-list__value">
+                        <button
+                          type="button"
+                          className="govuk-button"
+                          onClick={(e) => {
+                            e.preventDefault();
+                            setSelectedFormInstance(
+                              formInstanceKey !== selectedFormInstanceKey ? formInstance : null
+                            );
                           }}
-                        />
-                      )}
-                    </dd>
-                  </div>
-                </dl>
-              </div>
-            </details>
-            {index < formReferences.length - 1 ? <hr className="form-seperator" /> : null}
-          </React.Fragment>
-        );
-      })}
+                        >
+                          {isSelectedFormInstance ? 'Hide Details' : 'Show details'}
+                        </button>
+                        {form.isLoading && isSelectedFormInstance && (
+                          <h4 className="govuk-body">
+                            {t('pages.cases.details-panel.case-history.form-loading')}
+                          </h4>
+                        )}
+                        {!form.isLoading && isSelectedFormInstance && (
+                          <Form
+                            form={form.data}
+                            submission={{ data: submissionData }}
+                            options={{
+                              readOnly: true,
+                              noAlerts: true,
+                              buttonSettings: {
+                                showPrevious: true,
+                                showNext: true,
+                                showSubmit: false,
+                                showCancel: false,
+                              },
+                            }}
+                          />
+                        )}
+                      </dd>
+                    </div>
+                  </dl>
+                </div>
+              </details>
+              {index < formReferences.length - 1 ? <hr className="form-seperator" /> : null}
+            </React.Fragment>
+          );
+        })}
     </>
   );
 };

--- a/client/src/pages/cases/components/FormDetails.jsx
+++ b/client/src/pages/cases/components/FormDetails.jsx
@@ -111,7 +111,7 @@ const FormDetails = ({ formReferences, businessKey }) => {
                     </div>
                     <div className="govuk-summary-list__row">
                       <dt className="govuk-summary-list__key">
-                        {index === 0 ? <span className="govuk-tag">Latest</span> : null}
+                        {!index && <span className="govuk-tag">Latest</span>}
                       </dt>
                       <dd className="govuk-summary-list__value">
                         <button

--- a/client/src/pages/cases/components/FormDetails.jsx
+++ b/client/src/pages/cases/components/FormDetails.jsx
@@ -23,10 +23,6 @@ const FormDetails = ({ formReferences, businessKey }) => {
   const [submissionData, setSubmissionData] = useState(null);
   const [selectedFormInstance, setSelectedFormInstance] = useState(null);
 
-  // const sortFormReferenceses = formReferences.sort((a,b) => {
-  //   return new Date(b.submissionDate) - new Date(a.submissionDate)
-  // })
-
   const fetchForm = async (formName, formVersionId) => {
     if (axiosInstance) {
       try {

--- a/client/src/pages/cases/components/FormDetails.test.jsx
+++ b/client/src/pages/cases/components/FormDetails.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, queryByAttribute } from '@testing-library/react';
 import MockAdapter from 'axios-mock-adapter';
 import axios from 'axios';
 import { mount } from 'enzyme';
@@ -30,13 +30,14 @@ const formReferences = [
     dataPath: 'businessKey-12345/intelReferral/test-file-three.json',
     formVersionId: 'form-id-three',
     name: 'intelReferral',
-    submissionDate: '2021-02-05T16:31:42.224Z',
+    submissionDate: '2021-02-05T16:41:42.224Z',
     submittedBy: 'test3@digital.homeoffice.gov.uk',
     title: 'Intelligence Referral',
   },
 ];
 
 const mockAxios = new MockAdapter(axios);
+const getById = queryByAttribute.bind(null, 'id');
 
 const mockFetchForm = () => {
   mockAxios.onGet('/form/name/detectionInventory').reply(200, { jsonFormFixture });
@@ -70,7 +71,29 @@ describe('Form details component', () => {
     expect(screen.getByText('test1@digital.homeoffice.gov.uk')).toBeTruthy();
     expect(screen.getByText('Record border event')).toBeTruthy();
     expect(screen.getByText('Intelligence Referral')).toBeTruthy();
-    expect(screen.getAllByText('05/02/2021 16:31')).toHaveLength(2);
+    expect(screen.getByText('05/02/2021 16:31')).toBeTruthy();
+  });
+
+  it('should show forms in order of submission date with latest first', () => {
+    const { container } = render(
+      <FormDetails businessKey={businessKey} formReferences={formReferences} />
+    );
+
+    const firstFormDetailComponent = getById(container, 'form0');
+
+    expect(firstFormDetailComponent.textContent).toMatch(/^Intelligence Referral/);
+  });
+
+  it('should only show Latest label on first form detail drop down', () => {
+    const { container } = render(
+      <FormDetails businessKey={businessKey} formReferences={formReferences} />
+    );
+
+    const firstFormDetailComponent = getById(container, 'form0');
+    const secondFormDetailComponent = getById(container, 'form1');
+
+    expect(firstFormDetailComponent.textContent).toMatch(/Latest/g);
+    expect(secondFormDetailComponent.textContent).not.toMatch(/Latest/g);
   });
 
   it('should show a loading message and then the form snapshot when "Show details" is clicked', async () => {


### PR DESCRIPTION
**Description**
This branch fixes a bug where "Latest" label is showing for all form instances under the Case History section on the Cases page. It puts the forms in the correct submission date order (from latest to oldest) and adds the Latest label for only the latest instance. It also updates the tests for this change. 

**To test**
- Run branch locally pointing proxy to dev. 
- Navigate to cases page. Search for a case which you know has multiple completed forms (e.g. http://localhost:3000/cases/DEV-20210628-1460). Go to Case History tab and select drop down that contains multiple forms (for this example, "Collect Event at Border" at the bottom).
- Click on the Form links one by one to open them. You will see they are now in the correct order with Latest first and a Latest Label on only the first. 